### PR TITLE
[FEAT] 완료 버튼 컴포넌트 구현

### DIFF
--- a/MUMENT/MUMENT.xcodeproj/project.pbxproj
+++ b/MUMENT/MUMENT.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C73FC9B4287AEA510017F2DA /* MumentCompleteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73FC9B3287AEA510017F2DA /* MumentCompleteButton.swift */; };
 		C74EC41A28758D220068EB46 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74EC41928758D220068EB46 /* AppDelegate.swift */; };
 		C74EC41C28758D220068EB46 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74EC41B28758D220068EB46 /* SceneDelegate.swift */; };
 		C74EC42328758D230068EB46 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C74EC42228758D230068EB46 /* Assets.xcassets */; };
@@ -52,6 +53,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		C73FC9B3287AEA510017F2DA /* MumentCompleteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentCompleteButton.swift; sourceTree = "<group>"; };
 		C74EC41628758D220068EB46 /* MUMENT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MUMENT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C74EC41928758D220068EB46 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C74EC41B28758D220068EB46 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 			isa = PBXGroup;
 			children = (
 				C7BC6B502876AD8C008C75CE /* DefaultNavigationView.swift */,
+				C73FC9B3287AEA510017F2DA /* MumentCompleteButton.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				C7BB531C28759E0200E0E889 /* WriteVC.swift in Sources */,
 				C7BB531628759BBD00E0E889 /* MumentTabBarController.swift in Sources */,
 				C7BC6B6228771020008C75CE /* UICollectionView+.swift in Sources */,
+				C73FC9B4287AEA510017F2DA /* MumentCompleteButton.swift in Sources */,
 				C7BB531A28759DE500E0E889 /* HomeVC.swift in Sources */,
 				C7BB531E28759E6500E0E889 /* StorageVC.swift in Sources */,
 				C7BC6B722877ECA0008C75CE /* CALayer+.swift in Sources */,

--- a/MUMENT/MUMENT/Sources/Components/MumentCompleteButton.swift
+++ b/MUMENT/MUMENT/Sources/Components/MumentCompleteButton.swift
@@ -1,0 +1,38 @@
+//
+//  MumentCompleteButton.swift
+//  MUMENT
+//
+//  Created by madilyn on 2022/07/10.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+class MumentCompleteButton: UIButton {
+    
+    // MARK: - Initialization
+    init(isEnabled: Bool) {
+        super.init(frame: .zero)
+        setDefaultStyle(isEnabled: isEnabled)
+    }
+    
+    required init(coder aDecoder: NSCoder, isEnabled: Bool) {
+        super.init(coder: aDecoder)!
+        setDefaultStyle(isEnabled: isEnabled)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UI
+    private func setDefaultStyle(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+        self.makeRounded(cornerRadius: 11.adjustedH)
+        self.setBackgroundColor(.mPurple1, for: .normal)
+        self.setBackgroundColor(.mGray2, for: .disabled)
+        self.setTitleColor(.mWhite, for: .normal)
+        self.titleLabel?.font = .mumentH2B18
+    }
+}


### PR DESCRIPTION
## 🎸 작업한 내용
- 완료 버튼을 컴포넌트로 빼서 구현하였습니다!

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 인스턴스 생성
```
    private let completeButton = MumentCompleteButton(isEnabled: true).then {
        $0.setTitle("완료", for: .normal)
    }
```
- 레이아웃 설정
```
completeButton.snp.makeConstraints {
            $0.top.equalTo(원하는 곳)
            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
            $0.height.equalTo(47.adjustedH)
        }
```
- 터치 시 동작 설정
```
        completeButton.press {
            self.completeButton.isEnabled.toggle()
        }
```

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
- isEnabled == false
![        ](https://user-images.githubusercontent.com/43312096/178151722-d6f6b990-3855-4697-801c-640f5887812f.png)
- isEnabled == true

https://user-images.githubusercontent.com/43312096/178151738-91f8a785-cfac-4636-a0c2-15a90c58db87.mp4


## 💽 관련 이슈
- Resolved: #28

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
