### PR TITLE
[FEAT] 태그별 뮤멘트 추천 섹션 구현

### DIFF
--- a/MUMENT/MUMENT.xcodeproj/project.pbxproj
+++ b/MUMENT/MUMENT.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4D2BADCA2880334C004A7E00 /* MumentsByTagCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2BADC92880334C004A7E00 /* MumentsByTagCVC.swift */; };
 		4D2BADCC288033E0004A7E00 /* MumentsByTagModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2BADCB288033E0004A7E00 /* MumentsByTagModel.swift */; };
+		4D2BADCE2880459F004A7E00 /* MumentsByTagTitleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2BADCD2880459F004A7E00 /* MumentsByTagTitleModel.swift */; };
 		4D4C8658287BCD3D00D972AF /* CarouselCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4C8657287BCD3D00D972AF /* CarouselCVC.swift */; };
 		4D64A9E8287D810000450FCA /* MumentCardWithoutHeartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D64A9E7287D810000450FCA /* MumentCardWithoutHeartView.swift */; };
 		4D64A9EA287D885A00450FCA /* DefaultTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D64A9E9287D885A00450FCA /* DefaultTagView.swift */; };
@@ -81,6 +82,7 @@
 /* Begin PBXFileReference section */
 		4D2BADC92880334C004A7E00 /* MumentsByTagCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentsByTagCVC.swift; sourceTree = "<group>"; };
 		4D2BADCB288033E0004A7E00 /* MumentsByTagModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentsByTagModel.swift; sourceTree = "<group>"; };
+		4D2BADCD2880459F004A7E00 /* MumentsByTagTitleModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentsByTagTitleModel.swift; sourceTree = "<group>"; };
 		4D4C8657287BCD3D00D972AF /* CarouselCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCVC.swift; sourceTree = "<group>"; };
 		4D64A9E7287D810000450FCA /* MumentCardWithoutHeartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentCardWithoutHeartView.swift; sourceTree = "<group>"; };
 		4D64A9E9287D885A00450FCA /* DefaultTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTagView.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				C7BC6B552876ADCD008C75CE /* CarouselModel.swift */,
 				4D9734EE287EC748003EF546 /* MumentsOfRevisitedModel.swift */,
 				4D2BADCB288033E0004A7E00 /* MumentsByTagModel.swift */,
+				4D2BADCD2880459F004A7E00 /* MumentsByTagTitleModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -526,6 +529,7 @@
 				C7BB531428759AB200E0E889 /* Adjusted+.swift in Sources */,
 				C7BB531828759CF000E0E889 /* UITabBar+.swift in Sources */,
 				4D696CF12879784C0060CE41 /* MumentsByTagTVC.swift in Sources */,
+				4D2BADCE2880459F004A7E00 /* MumentsByTagTitleModel.swift in Sources */,
 				4D2BADCA2880334C004A7E00 /* MumentsByTagCVC.swift in Sources */,
 				C7BB53102875990700E0E889 /* BaseVC.swift in Sources */,
 				C74EC438287593110068EB46 /* UIColor+.swift in Sources */,

--- a/MUMENT/MUMENT.xcodeproj/project.pbxproj
+++ b/MUMENT/MUMENT.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D2BADCA2880334C004A7E00 /* MumentsByTagCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2BADC92880334C004A7E00 /* MumentsByTagCVC.swift */; };
+		4D2BADCC288033E0004A7E00 /* MumentsByTagModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2BADCB288033E0004A7E00 /* MumentsByTagModel.swift */; };
 		4D4C8658287BCD3D00D972AF /* CarouselCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4C8657287BCD3D00D972AF /* CarouselCVC.swift */; };
 		4D64A9E8287D810000450FCA /* MumentCardWithoutHeartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D64A9E7287D810000450FCA /* MumentCardWithoutHeartView.swift */; };
 		4D64A9EA287D885A00450FCA /* DefaultTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D64A9E9287D885A00450FCA /* DefaultTagView.swift */; };
@@ -77,6 +79,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4D2BADC92880334C004A7E00 /* MumentsByTagCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentsByTagCVC.swift; sourceTree = "<group>"; };
+		4D2BADCB288033E0004A7E00 /* MumentsByTagModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentsByTagModel.swift; sourceTree = "<group>"; };
 		4D4C8657287BCD3D00D972AF /* CarouselCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCVC.swift; sourceTree = "<group>"; };
 		4D64A9E7287D810000450FCA /* MumentCardWithoutHeartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentCardWithoutHeartView.swift; sourceTree = "<group>"; };
 		4D64A9E9287D885A00450FCA /* DefaultTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTagView.swift; sourceTree = "<group>"; };
@@ -305,10 +309,11 @@
 				4D696CE8287975740060CE41 /* HomeTVHeader.swift */,
 				4D696CEA287975800060CE41 /* CarouselTVC.swift */,
 				4D4C8657287BCD3D00D972AF /* CarouselCVC.swift */,
+				4D696CF2287978630060CE41 /* MumentForTodayTVC.swift */,
 				4D696CEE287978360060CE41 /* MumentsOfRevisitedTVC.swift */,
 				4D9734EC287EB022003EF546 /* MumentsOfRevisitedCVC.swift */,
-				4D696CF2287978630060CE41 /* MumentForTodayTVC.swift */,
 				4D696CF02879784C0060CE41 /* MumentsByTagTVC.swift */,
+				4D2BADC92880334C004A7E00 /* MumentsByTagCVC.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -399,6 +404,7 @@
 			children = (
 				C7BC6B552876ADCD008C75CE /* CarouselModel.swift */,
 				4D9734EE287EC748003EF546 /* MumentsOfRevisitedModel.swift */,
+				4D2BADCB288033E0004A7E00 /* MumentsByTagModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -520,6 +526,7 @@
 				C7BB531428759AB200E0E889 /* Adjusted+.swift in Sources */,
 				C7BB531828759CF000E0E889 /* UITabBar+.swift in Sources */,
 				4D696CF12879784C0060CE41 /* MumentsByTagTVC.swift in Sources */,
+				4D2BADCA2880334C004A7E00 /* MumentsByTagCVC.swift in Sources */,
 				C7BB53102875990700E0E889 /* BaseVC.swift in Sources */,
 				C74EC438287593110068EB46 /* UIColor+.swift in Sources */,
 				C7BC6B562876ADCD008C75CE /* CarouselModel.swift in Sources */,
@@ -529,6 +536,7 @@
 				C73FC9C6287C19D30017F2DA /* GenericResponse.swift in Sources */,
 				C73FC9CE287C19F40017F2DA /* EventLogger.swift in Sources */,
 				C7BC6B6028770FB6008C75CE /* UILabel+.swift in Sources */,
+				4D2BADCC288033E0004A7E00 /* MumentsByTagModel.swift in Sources */,
 				4D696CE9287975740060CE41 /* HomeTVHeader.swift in Sources */,
 				C7BC6B5E28770902008C75CE /* NSObject+.swift in Sources */,
 				C7BB53002875960800E0E889 /* UIFont+.swift in Sources */,

--- a/MUMENT/MUMENT/Sources/Scenes/Home/HomeTVHeader.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/HomeTVHeader.swift
@@ -21,7 +21,7 @@ class HomeTVHeader: UIView {
     }
     
     lazy var searchButton = UIButton().then{
-        $0.setTitle("뮤멘트를 둘러보세요.", for: .normal)
+        $0.setTitle("어떤 노래가 궁금하신가요?", for: .normal)
         $0.setTitleColor(.mGray1, for: .normal)
         $0.titleLabel?.font = .mumentB2B14
         $0.backgroundColor = .mGray5

--- a/MUMENT/MUMENT/Sources/Scenes/Home/HomeVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/HomeVC.swift
@@ -112,8 +112,10 @@ extension HomeVC: UITableViewDelegate {
             cellHeight = 300
         case 1:
             cellHeight = 300
-        case 2...3:
+        case 2:
             cellHeight = 350
+        case 3:
+            cellHeight = 280
         default:
             cellHeight = 0
         }

--- a/MUMENT/MUMENT/Sources/Scenes/Home/Model/MumentsByTagModel.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/Model/MumentsByTagModel.swift
@@ -1,0 +1,31 @@
+//
+//  MumentsByTagModel.swift
+//  MUMENT
+//
+//  Created by 김지민 on 2022/07/14.
+//
+
+import UIKit
+
+struct MumentsByTagModel {
+    let title: String
+    let artist: String
+    let contents: String
+    let profileImageName: String
+    var profileImage: UIImage? {
+        return UIImage(named:profileImageName)
+    }
+    let writerName:String
+}
+
+// MARK: - Extensions
+extension MumentsByTagModel {
+    static var sampleData: [MumentsByTagModel] = [
+        MumentsByTagModel(title:"민수는 혼란스럽다", artist: "민수", contents: "옷을 되는 봄날의 실현에 싹이 꾸며 몸이 사막이다. 든 동력은 피가 그리하였는가? 그러므로 수 같은 오아이스도 우는 사막이다. 능히 것은 생생하며, 청춘에서만 우리의 방황하여도, 있는 위하여 귀는 이상 아니더면, 철환하였는가? 가지에 가치를 피가 위하여 우리의 때문이다.", profileImageName:"image3", writerName: "이수지"),
+        MumentsByTagModel(title:"Antifreeze", artist: "백예린", contents: "어머니, 이네들은 거외다. 말 이름을 슬퍼하는 이웃 봅니다. 인생에 있는가?불어 얼음과 천자만홍이 풍부하게 역사를 이것이다. 이것은 풀이 대한 이것이다. 못하다 무한한 오직 날카로우나 청춘에서만 밝은 불어 고동을 같지 있다. 얼음이 바이며, 생생하며, 뿐이다. ", profileImageName:"image4", writerName: "이수지"),
+        MumentsByTagModel(title:"하늘나라", artist: "혁오", contents: "인생을 따뜻한 귀는 예수는 피어나기 앞이 행복스럽고 아름다우냐? 갑 두손을 꾸며 구하지 산야에 위하여서. 사라지지 웅대한 속잎나고, 있으랴? 평화스러운 피어나는 것은 열매를 이상을 있다. 영원히 길지 것이 끓는다.", profileImageName:"image2", writerName: "이수지"),
+        MumentsByTagModel(title:"덩", artist: "새소년", contents: "긴지라 모래뿐일 구하지 웅대한 산야에 얼마나 얼음이 피고, 이것이다. 간에 것은 위하여, 이상이 고행을 있음으로써 찾아다녀도, 든 있으랴? 현저하게 두손을 청춘을 아니다. 피부가 현저하게 대고, 때까지 미인을 눈에 속에서 인간의 바로 그리하였는가?", profileImageName:"image4", writerName: "이수지"),
+        MumentsByTagModel(title:"빨간 맛", artist: "레드벨벳", contents: " 그들은 이 무엇을 피가 희망의 없는 기관과 있는가? 눈이 타오르고 굳세게 두기 그림자는 그리하였는가? 방황하여도, 불어 대고, 인류의 튼튼하며, 영원히 낙원을 피에 그들의 피다. 모래뿐일 위하여, 봄바람을 유소년에게서 인간의 보이는 사람은 말이다.", profileImageName:"image5", writerName: "이수지")
+    ]
+}
+

--- a/MUMENT/MUMENT/Sources/Scenes/Home/Model/MumentsByTagTitleModel.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/Model/MumentsByTagTitleModel.swift
@@ -1,0 +1,18 @@
+//
+//  MumentsByTagTitleModel.swift
+//  MUMENT
+//
+//  Created by 김지민 on 2022/07/14.
+//
+
+import UIKit
+
+struct MumentsByTagTitleModel {
+    let title: String
+}
+
+// MARK: - Extensions
+extension MumentsByTagTitleModel {
+    static var sampleData: MumentsByTagTitleModel = MumentsByTagTitleModel(title:"설렘")
+}
+

--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagCVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagCVC.swift
@@ -1,0 +1,151 @@
+//
+//  MumentsByTagCVC.swift
+//  MUMENT
+//
+//  Created by 김지민 on 2022/07/14.
+//
+import UIKit
+import SnapKit
+import Then
+
+class MumentsByTagCVC: UICollectionViewCell {
+    
+    // MARK: - Properties
+    lazy var titleSectionStackView = UIStackView(arrangedSubviews: [titleIconImage, titleAndArtistLabel]).then{
+        $0.axis = .horizontal
+        $0.spacing = 5
+    }
+    
+    private let titleIconImage = UIImageView().then{
+        $0.image = UIImage(named: "mumentMusicnote")
+    }
+//        .then{
+//        $0.makeRounded(cornerRadius: 12)
+//        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+//        $0.clipsToBounds = true
+//    }
+//
+//    lazy var contentsStackView = UIStackView(arrangedSubviews: [mumentInfoStackView, writerInfoStackView]).then{
+//        $0.axis = .vertical
+//        $0.spacing = 12
+//    }
+    
+//    lazy var mumentInfoStackView = UIStackView(arrangedSubviews: [titleLabel, contentsLabel]).then{
+//        $0.axis = .vertical
+//        $0.spacing = 5
+//    }
+    
+    private let titleAndArtistLabel = UILabel().then{
+        $0.textColor = .mBlack2
+        $0.font = .mumentB5B13
+    }
+    
+//    private let titleLabel = UILabel().then{
+//        $0.textColor = .mBlack2
+//        $0.font = .mumentB5B13
+//    }
+//
+//    private let artistLabel = UILabel().then{
+//        $0.textColor = .mBlack2
+//        $0.font = .mumentB5B13
+//    }
+    
+    private let contentsLabel = UILabel().then{
+        $0.textColor = .mGray1
+        $0.font = .mumentB6M13
+        $0.lineBreakMode = .byTruncatingTail
+        $0.numberOfLines = 6
+    }
+    
+    let separatorView = UIView().then{
+        $0.backgroundColor = .mGray4
+    }
+    
+    lazy var writerInfoStackView = UIStackView(arrangedSubviews: [profileImage, writerNameLabel]).then{
+        $0.axis = .horizontal
+        $0.spacing = 6
+    }
+    private var profileImage = UIImageView().then{
+        $0.makeRounded(cornerRadius: 9.5)
+    }
+    private let writerNameLabel = UILabel().then{
+        $0.textColor = .mGray1
+        $0.font = .mumentC1R12
+    }
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setLayout()
+        setUI()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    //MARK: - Functions
+    func setData(_ cellData: MumentsByTagModel){
+//        titleIconImage.image = cellData.albumImage
+        titleAndArtistLabel.text = "\(cellData.title) - \(cellData.artist)"
+//        titleLabel.text = cellData.title
+//        artistLabel.text = cellData.artist
+        contentsLabel.text = cellData.contents
+        profileImage.image = cellData.profileImage
+        writerNameLabel.text = cellData.writerName
+    }
+}
+
+// MARK: - UI
+extension MumentsByTagCVC {
+    
+    private func setUI(){
+        self.makeRounded(cornerRadius: 11)
+        self.backgroundColor = .mWhite
+        self.addShadow(offset: CGSize(width: 0, height: -2),opacity: 0.2,radius: 4.0)
+    }
+    
+    private func setLayout() {
+        
+        self.addSubviews([titleSectionStackView,contentsLabel,separatorView,writerInfoStackView])
+        
+        titleSectionStackView.snp.makeConstraints{
+            $0.top.equalTo(self.safeAreaLayoutGuide).offset(19)
+            $0.left.equalTo(self.safeAreaLayoutGuide).offset(13)
+            $0.right.equalTo(self.safeAreaLayoutGuide).inset(13)
+//            $0.leading.top.trailing.equalTo(self.safeAreaLayoutGuide)
+//            $0.width.height.equalTo(160)
+        }
+        
+        contentsLabel.snp.makeConstraints{
+            $0.top.equalTo(titleSectionStackView.snp.bottom).offset(10)
+            $0.leading.equalTo(self.safeAreaLayoutGuide.snp.leading).offset(13)
+            $0.trailing.equalTo(self.safeAreaLayoutGuide.snp.trailing).inset(13)
+//            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(11)
+        }
+        
+        separatorView.snp.makeConstraints{
+            $0.left.equalTo(self.safeAreaLayoutGuide).offset(13)
+            $0.right.equalTo(self.safeAreaLayoutGuide).inset(13)
+            $0.top.equalTo(contentsLabel.snp.bottom).offset(15)
+            $0.height.equalTo(1)
+        }
+        
+        writerInfoStackView.snp.makeConstraints{
+            $0.top.equalTo(separatorView.snp.bottom).offset(10)
+            $0.left.equalTo(self.safeAreaLayoutGuide).offset(13)
+            $0.right.equalTo(self.safeAreaLayoutGuide).inset(13)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(13)
+        }
+        
+        titleIconImage.snp.makeConstraints{
+            $0.height.width.equalTo(12)
+        }
+        
+        profileImage.snp.makeConstraints{
+            $0.height.width.equalTo(24)
+        }
+    }
+}
+

--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagCVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagCVC.swift
@@ -19,36 +19,11 @@ class MumentsByTagCVC: UICollectionViewCell {
     private let titleIconImage = UIImageView().then{
         $0.image = UIImage(named: "mumentMusicnote")
     }
-//        .then{
-//        $0.makeRounded(cornerRadius: 12)
-//        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-//        $0.clipsToBounds = true
-//    }
-//
-//    lazy var contentsStackView = UIStackView(arrangedSubviews: [mumentInfoStackView, writerInfoStackView]).then{
-//        $0.axis = .vertical
-//        $0.spacing = 12
-//    }
-    
-//    lazy var mumentInfoStackView = UIStackView(arrangedSubviews: [titleLabel, contentsLabel]).then{
-//        $0.axis = .vertical
-//        $0.spacing = 5
-//    }
     
     private let titleAndArtistLabel = UILabel().then{
         $0.textColor = .mBlack2
         $0.font = .mumentB5B13
     }
-    
-//    private let titleLabel = UILabel().then{
-//        $0.textColor = .mBlack2
-//        $0.font = .mumentB5B13
-//    }
-//
-//    private let artistLabel = UILabel().then{
-//        $0.textColor = .mBlack2
-//        $0.font = .mumentB5B13
-//    }
     
     private let contentsLabel = UILabel().then{
         $0.textColor = .mGray1
@@ -87,10 +62,7 @@ class MumentsByTagCVC: UICollectionViewCell {
     
     //MARK: - Functions
     func setData(_ cellData: MumentsByTagModel){
-//        titleIconImage.image = cellData.albumImage
         titleAndArtistLabel.text = "\(cellData.title) - \(cellData.artist)"
-//        titleLabel.text = cellData.title
-//        artistLabel.text = cellData.artist
         contentsLabel.text = cellData.contents
         profileImage.image = cellData.profileImage
         writerNameLabel.text = cellData.writerName
@@ -114,15 +86,12 @@ extension MumentsByTagCVC {
             $0.top.equalTo(self.safeAreaLayoutGuide).offset(19)
             $0.left.equalTo(self.safeAreaLayoutGuide).offset(13)
             $0.right.equalTo(self.safeAreaLayoutGuide).inset(13)
-//            $0.leading.top.trailing.equalTo(self.safeAreaLayoutGuide)
-//            $0.width.height.equalTo(160)
         }
         
         contentsLabel.snp.makeConstraints{
             $0.top.equalTo(titleSectionStackView.snp.bottom).offset(10)
             $0.leading.equalTo(self.safeAreaLayoutGuide.snp.leading).offset(13)
             $0.trailing.equalTo(self.safeAreaLayoutGuide.snp.trailing).inset(13)
-//            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(11)
         }
         
         separatorView.snp.makeConstraints{

--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagTVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagTVC.swift
@@ -13,8 +13,9 @@ class MumentsByTagTVC: UITableViewCell {
     
     // MARK: - Properties
     var dataSource: [MumentsByTagModel] = MumentsByTagModel.sampleData
+    var titleDataSource: MumentsByTagTitleModel = MumentsByTagTitleModel.sampleData
     lazy var titleLabel = UILabel().then{
-//        $0.text = "\()을 느낀 순간"
+//        $0.text  = "111111"
         $0.textColor = .mBlack1
         $0.font = .mumentH2B18
     }
@@ -27,6 +28,7 @@ class MumentsByTagTVC: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setCV()
         setLayout()
+        setData(titleDataSource)
         selectionStyle = .none
     }
     
@@ -43,6 +45,10 @@ class MumentsByTagTVC: UITableViewCell {
         
         mumentCV.showsHorizontalScrollIndicator = false
         CVFlowLayout.scrollDirection = .horizontal
+    }
+    
+    func setData(_ cellData: MumentsByTagTitleModel){
+        titleLabel.text = "\(cellData.title)을 느낀 순간"
     }
 }
 

--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagTVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagTVC.swift
@@ -15,7 +15,6 @@ class MumentsByTagTVC: UITableViewCell {
     var dataSource: [MumentsByTagModel] = MumentsByTagModel.sampleData
     var titleDataSource: MumentsByTagTitleModel = MumentsByTagTitleModel.sampleData
     lazy var titleLabel = UILabel().then{
-//        $0.text  = "111111"
         $0.textColor = .mBlack1
         $0.font = .mumentH2B18
     }
@@ -65,7 +64,6 @@ extension MumentsByTagTVC {
         
         mumentCV.snp.makeConstraints{
             $0.top.equalTo(titleLabel.snp.bottom).offset(18)
-//            $0.leading.trailing.bottom.equalTo(self.safeAreaLayoutGuide)
             $0.trailing.bottom.equalTo(self.safeAreaLayoutGuide)
             $0.leading.equalTo(self.safeAreaLayoutGuide).offset(20)
         }

--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagTVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentsByTagTVC.swift
@@ -12,21 +12,37 @@ import Then
 class MumentsByTagTVC: UITableViewCell {
     
     // MARK: - Properties
+    var dataSource: [MumentsByTagModel] = MumentsByTagModel.sampleData
     lazy var titleLabel = UILabel().then{
-        $0.text = "MumentsByTag"
-        $0.font = .systemFont(ofSize: 16)
-        $0.textColor = .black
+//        $0.text = "\()을 느낀 순간"
+        $0.textColor = .mBlack1
+        $0.font = .mumentH2B18
     }
+    private lazy var mumentCV = UICollectionView(frame: .zero, collectionViewLayout: CVFlowLayout)
+    private let CVFlowLayout = UICollectionViewFlowLayout()
+    
     
     // MARK: - Initialization
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setCV()
         setLayout()
+        selectionStyle = .none
     }
     
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    private func setCV() {
+        mumentCV.delegate = self
+        mumentCV.dataSource = self
+        mumentCV.register(MumentsByTagCVC.self, forCellWithReuseIdentifier: MumentsByTagCVC.className)
+        
+        mumentCV.showsHorizontalScrollIndicator = false
+        CVFlowLayout.scrollDirection = .horizontal
     }
 }
 
@@ -34,14 +50,47 @@ class MumentsByTagTVC: UITableViewCell {
 extension MumentsByTagTVC {
     
     private func setLayout() {
-        self.addSubviews([titleLabel])
         
-        backgroundColor = .systemGreen
-        selectionStyle = .none
+        self.addSubviews([titleLabel,mumentCV])
         
         titleLabel.snp.makeConstraints{
-            $0.leading.top.equalTo(self.safeAreaLayoutGuide).offset(42)
+            $0.leading.top.equalTo(self.safeAreaLayoutGuide).offset(20)
         }
         
+        mumentCV.snp.makeConstraints{
+            $0.top.equalTo(titleLabel.snp.bottom).offset(18)
+//            $0.leading.trailing.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.trailing.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.leading.equalTo(self.safeAreaLayoutGuide).offset(20)
+        }
+        
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+extension MumentsByTagTVC: UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return dataSource.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MumentsByTagCVC.className, for: indexPath) as?  MumentsByTagCVC else {
+            return UICollectionViewCell()
+        }
+        
+        cell.setData(dataSource[indexPath.row])
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+extension MumentsByTagTVC: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        let cellWidth = 200
+        let cellHeight = 200
+        
+        return CGSize(width: cellWidth, height: cellHeight)
     }
 }


### PR DESCRIPTION
## 🎸 작업한 내용
- 홈 뷰의 태그별 뮤멘트 추천 섹션을 구현했습니다.
- 뮤멘트 작성할 곡 검색창 placeholder를 수정했습니다. 

## 🎶 PR Point
- 항상 꼼꼼하게 피드백 해주셔서 감사합니다! 

## 📸 스크린샷
![Simulator Screen Recording - iPhone SE (3rd generation) - 2022-07-14 at 21 52 26](https://user-images.githubusercontent.com/25932970/178986717-7efe7c2b-87d2-44e8-8a7e-fae9c0350d57.gif)

## 💽 관련 이슈
- Resolved: #16 
