### PR TITLE
[FEAT] 확인, 취소 Alert 재사용 컴포넌트 구현 [FEAT] 검색-모두삭제 Alert 적용

### DIFF
--- a/MUMENT/MUMENT/Sources/Components/MumentAlertWithButtons/MumentAlertWithButtons.swift
+++ b/MUMENT/MUMENT/Sources/Components/MumentAlertWithButtons/MumentAlertWithButtons.swift
@@ -72,7 +72,7 @@ class MumentAlertWithButtons: BaseVC{
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
-        setButtonAction()()
+        setButtonAction()
         setDefaultLayout()
         
         setButtonStackViewLayout()

--- a/MUMENT/MUMENT/Sources/Components/MumentAlertWithButtons/MumentAlertWithButtons.swift
+++ b/MUMENT/MUMENT/Sources/Components/MumentAlertWithButtons/MumentAlertWithButtons.swift
@@ -72,7 +72,7 @@ class MumentAlertWithButtons: BaseVC{
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
-        setCancelButtonAction()
+        setButtonAction()()
         setDefaultLayout()
         
         setButtonStackViewLayout()
@@ -103,8 +103,11 @@ class MumentAlertWithButtons: BaseVC{
         self.modalTransitionStyle = .crossDissolve
     }
     
-    func setCancelButtonAction() {
+    func setButtonAction() {
         cancelButton.press { [weak self] in
+            self?.dismiss(animated: true)
+        }
+        OKButton.press { [weak self] in
             self?.dismiss(animated: true)
         }
     }

--- a/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
@@ -83,9 +83,17 @@ class SearchVC: BaseVC {
     // MARK: - Functions
     private func setAllClearButton() {
         allClearButton.press { [weak self] in
-            self?.recentSearchDummyData = []
-            self?.resultTV.reloadData()
-            self?.setRecentSearchEmptyView()
+            let mumentAlert = MumentAlertWithButtons(titleType: .onlyTitleLabel)
+            mumentAlert.setTitle(title: """
+최근 검색한 내역을
+모두 삭제하시겠어요?
+""")
+            mumentAlert.OKButton.press {
+                self?.recentSearchDummyData = []
+                self?.resultTV.reloadData()
+                self?.setRecentSearchEmptyView()
+            }
+            self?.present(mumentAlert, animated: true)
         }
     }
     


### PR DESCRIPTION
## 🎸 작업한 내용
- 확인, 취소 Alert 재사용 컴포넌트를 검색-모두삭제 버튼에 적용하였습니다.

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
### MumentAlertWithButtons 
 - type: .onlyTitleLabel
 ```
        let mumentAlert = MumentAlertWithButtons(titleType: .onlyTitleLabel)
        mumentAlert.setTitle(title: "파이팅!")
```
![image](https://user-images.githubusercontent.com/43312096/179416412-2b709ec6-c40f-4a38-9638-9f5e6e841de9.png)

  - type: .onlyTitleLabel
 ```
        let mumentAlert2 = MumentAlertWithButtons(titleType: .onlyTitleLabel)
        mumentAlert.setTitle(title: """
방가방가
안녕하세요~
""")
```
![image](https://user-images.githubusercontent.com/43312096/179416397-46e7da10-8224-4c5f-a96d-64d72f349545.png)

  - type: .containedSubTitleLabel
 ```
        let mumentAlert3 = MumentAlertWithButtons(titleType: .containedSubTitleLabel)
        mumentAlert3.setTitleSubTitle(title: "여기는 알럿입니다", subTitle: "여기는 서브타이틀임")
```
![image](https://user-images.githubusercontent.com/43312096/179416405-e5b25390-b9ce-4160-b8ca-5f1c8e518b05.png)

- 확인 버튼 액션 세팅
```
        mumentAlert.OKButton.press { [weak self] in
            print("확인 버튼 pressed")
        }
```
 - present 띄우기!!!!!!!!!!!!!!!
 ```
self.present(mumentAlert, animated: true)
```


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

![Simulator Screen Recording - iPhone SE (2nd generation) - 2022-07-18 at 01 58 39](https://user-images.githubusercontent.com/43312096/179416490-6ff28c60-0823-45d3-82e4-e10db38d72eb.gif)

## 💽 관련 이슈
- Resolved: #61 
- Resolved: #63

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
