### PR TITLE
[FEAT] 뮤멘트 상세보기 팝업 창 구현 

### DIFF
--- a/MUMENT/MUMENT/Sources/Components/DetailMumentCard/DetailMumentCardView.swift
+++ b/MUMENT/MUMENT/Sources/Components/DetailMumentCard/DetailMumentCardView.swift
@@ -24,7 +24,7 @@ class DetailMumentCardView: UIView {
         $0.font = .mumentB6M13
     }
     
-    private let menuIconButton = UIButton().then{
+    let menuIconButton = UIButton().then{
         $0.configuration = .plain()
         $0.configuration?.image = UIImage(named: "kebab")
     }

--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/MumentDetailVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/MumentDetailVC.swift
@@ -71,23 +71,7 @@ class MumentDetailVC: BaseVC, UIActionSheetDelegate {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView(_:)))
         mumentCardView.songInfoView.addGestureRecognizer(tapGestureRecognizer)
         mumentCardView.menuIconButton.press{
-//            let actionSheet = UIActionSheet(title: "Choose Option", delegate: self, cancelButtonTitle: "Cancel", destructiveButtonTitle: nil, otherButtonTitles: "Save", "Delete")
-            
-//            actionSheet.show(in: self.view)let alert = UIAlertController(title: "Title", message: "Please Select an Option", preferredStyle: .actionSheet)
-            
-            
-            
-//            let alert = UIAlertController(title: "Title", message: "Please Select an Option", preferredStyle: .actionSheet)
 
-//            alert.addAction(UIAlertAction(title: "Approve", style: .default , handler:{ (UIAlertAction)in
-//                print("User click Approve button")
-//            }))
-
-//            self.present(alert, animated: true, completion: {
-//                    print("completion block")
-//            })
-            
-            
             let actionSheetController: UIAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
             let firstAction: UIAlertAction = UIAlertAction(title: "수정하기", style: .default) { action -> Void in

--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/MumentDetailVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/MumentDetailVC.swift
@@ -74,11 +74,11 @@ class MumentDetailVC: BaseVC, UIActionSheetDelegate {
 
             let actionSheetController: UIAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-            let firstAction: UIAlertAction = UIAlertAction(title: "수정하기", style: .default) { action -> Void in
+            let updatingAction: UIAlertAction = UIAlertAction(title: "수정하기", style: .default) { action -> Void in
                 self.tabBarController?.selectedIndex = 1
             }
 
-            let secondAction: UIAlertAction = UIAlertAction(title: "삭제하기", style: .default) { action -> Void in
+            let deletingAction: UIAlertAction = UIAlertAction(title: "삭제하기", style: .default) { action -> Void in
                 let mumentAlert = MumentAlertWithButtons(titleType: .onlyTitleLabel)
                     mumentAlert.setTitle(title: "삭제하시겠어요?")
                 self.present(mumentAlert, animated: true)
@@ -90,8 +90,8 @@ class MumentDetailVC: BaseVC, UIActionSheetDelegate {
 
             let cancelAction: UIAlertAction = UIAlertAction(title: "취소", style: .cancel) { action -> Void in }
 
-            actionSheetController.addAction(firstAction)
-            actionSheetController.addAction(secondAction)
+            actionSheetController.addAction(updatingAction)
+            actionSheetController.addAction(deletingAction)
             actionSheetController.addAction(cancelAction)
 
             self.present(actionSheetController, animated: true) {

--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/MumentDetailVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/MumentDetailVC.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-class MumentDetailVC: BaseVC {
+class MumentDetailVC: BaseVC, UIActionSheetDelegate {
     
     // MARK: - Properties
     private let navigationBarView = DefaultNavigationBar()
@@ -70,6 +70,51 @@ class MumentDetailVC: BaseVC {
         
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView(_:)))
         mumentCardView.songInfoView.addGestureRecognizer(tapGestureRecognizer)
+        mumentCardView.menuIconButton.press{
+//            let actionSheet = UIActionSheet(title: "Choose Option", delegate: self, cancelButtonTitle: "Cancel", destructiveButtonTitle: nil, otherButtonTitles: "Save", "Delete")
+            
+//            actionSheet.show(in: self.view)let alert = UIAlertController(title: "Title", message: "Please Select an Option", preferredStyle: .actionSheet)
+            
+            
+            
+//            let alert = UIAlertController(title: "Title", message: "Please Select an Option", preferredStyle: .actionSheet)
+
+//            alert.addAction(UIAlertAction(title: "Approve", style: .default , handler:{ (UIAlertAction)in
+//                print("User click Approve button")
+//            }))
+
+//            self.present(alert, animated: true, completion: {
+//                    print("completion block")
+//            })
+            
+            
+            let actionSheetController: UIAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+            let firstAction: UIAlertAction = UIAlertAction(title: "수정하기", style: .default) { action -> Void in
+                self.tabBarController?.selectedIndex = 1
+            }
+
+            let secondAction: UIAlertAction = UIAlertAction(title: "삭제하기", style: .default) { action -> Void in
+                let mumentAlert = MumentAlertWithButtons(titleType: .onlyTitleLabel)
+                    mumentAlert.setTitle(title: "삭제하시겠어요?")
+                self.present(mumentAlert, animated: true)
+                
+                mumentAlert.OKButton.press {
+                    self.navigationController?.popViewController(animated: true)
+                            }
+            }
+
+            let cancelAction: UIAlertAction = UIAlertAction(title: "취소", style: .cancel) { action -> Void in }
+
+            actionSheetController.addAction(firstAction)
+            actionSheetController.addAction(secondAction)
+            actionSheetController.addAction(cancelAction)
+
+            self.present(actionSheetController, animated: true) {
+                print("option menu presented")
+            }
+        }
+        
     }
     
     @objc func didTapView(_ sender: UITapGestureRecognizer) {


### PR DESCRIPTION
## 🎸 작업한 내용
- 뮤멘트 상세보기 뷰의 케밥메뉴 클릭 시 나오는 팝업창과 클릭 버튼 이벤트를 처리합니다.

## 🎶 PR Point
- 수정, 삭제하기는 UIActionSheet가 deprecated됐다고 해 UIAlertAction으로 구현하였습니다.
- 수정하기 클릭 시 기록하기 탭으로 이동, 삭제하기 클릭 시 삭제 확인 alert창이 뜨도록 하였는데, 삭제 확인 alert창은 정빈 언니가 만들어 둔 MumentAlertWithButtons로 구현했습니다.
- 삭제확인 alert에서 확인을 누르면 뮤멘트 상세보기 이전 페이지로 돌아갑니다. 

## 📸 스크린샷
<img width="300" alt="스크린샷 2022-07-14 오전 2 45 14" src="https://user-images.githubusercontent.com/25932970/179914568-637f0b12-e940-49ba-b72c-c41924d5c7bb.gif" >

## 💽 관련 이슈
- Resolved: #22 
