### PR TITLE
[FIX] 검색하기 UI 및 로직 이슈 수정

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Home/SongDetail/SongDetailVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/SongDetail/SongDetailVC.swift
@@ -21,6 +21,7 @@ class SongDetailVC: BaseVC {
     var songInfoData: SongInfoResponseModel.Music = SongInfoResponseModel.Music(id: "", name: "", image: "", artist: "")
     var myMumentData: SongInfoResponseModel.MyMument = SongInfoResponseModel.MyMument(feelingTag: [], updatedAt: "", music: SongInfoResponseModel.MyMument.MyMumentMusic(id: ""), id: "", likeCount: 0, impressionTag: [], isDeleted: true, isPrivate: true, cardTag: [], date: "", isFirst: true, isLiked: true, v: 0, user: SongInfoResponseModel.MyMument.User(id: "", name: "", image: ""), createdAt: "", content: "")
     var allMumentsData: [AllMumentsResponseModel.MumentList] = []
+    var musicId: String?
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
@@ -196,14 +197,14 @@ extension SongDetailVC :AllMumentsSectionHeaderDelegate {
 // MARK: - Network
 extension SongDetailVC {
     private func requestGetSongInfo() {
-        SongDetailAPI.shared.getSongInfo(musicId: "62d29b39177f6e81ee8fa3f3", userId: "62cd5d4383956edb45d7d0ef") { networkResult in
+        SongDetailAPI.shared.getSongInfo(musicId: self.musicId ?? "", userId: UserInfo.shared.userId ?? "") { networkResult in
             switch networkResult {
                 
             case .success(let response):
                 if let res = response as? SongInfoResponseModel {
                     self.songInfoData = res.music
                     self.myMumentData = res.myMument
-                    self.mumentTV.reloadData()
+                    self.mumentTV.reloadSections(IndexSet(integer: 0), with: .automatic)
                 }
             default:
                 self.makeAlert(title: """
@@ -215,7 +216,7 @@ extension SongDetailVC {
     }
     
     private func requestGetAllMuments(_ isOrderLiked: Bool) {
-        SongDetailAPI.shared.getAllMuments(musicId: "62d29b39177f6e81ee8fa3f3", userId: "62cd5d4383956edb45d7d0ef", isOrderLiked: isOrderLiked) { networkResult in
+        SongDetailAPI.shared.getAllMuments(musicId: self.musicId ?? "", userId: UserInfo.shared.userId ?? "", isOrderLiked: isOrderLiked) { networkResult in
             switch networkResult {
                 
             case .success(let response):

--- a/MUMENT/MUMENT/Sources/Scenes/Search/EmptyView/RecentSearchEmptyView.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Search/EmptyView/RecentSearchEmptyView.swift
@@ -48,8 +48,9 @@ extension RecentSearchEmptyView {
         
         imageView.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.trailing.leading.equalToSuperview().inset(120)
-            $0.height.equalTo(109)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(135.adjustedW)
+            $0.height.equalTo(109.adjustedW)
         }
         
         titleLabel.snp.makeConstraints {

--- a/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
@@ -203,11 +203,15 @@ extension SearchVC {
 // MARK: - UITableViewDelegate
 extension SearchVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let songDetailVC = SongDetailVC()
+
         switch searchTVType {
         case .recentSearch:
-            recentSearchData.append(recentSearchData[indexPath.row])
-            recentSearchData.remove(at: indexPath.row)
+            songDetailVC.musicId = recentSearchData.reversed()[indexPath.row].id
+            recentSearchData.append(recentSearchData.reversed()[indexPath.row])
+            recentSearchData.remove(at: self.recentSearchData.count - indexPath.row - 2)
             SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: recentSearchData, forKey: UserDefaults.Keys.recentSearch)
+            
         case .searchResult:
             if recentSearchData.contains(searchResultData[indexPath.row]) {
                 recentSearchData.append(recentSearchData[indexPath.row])
@@ -217,11 +221,11 @@ extension SearchVC: UITableViewDelegate {
                 recentSearchData.append(searchResultData[indexPath.row])
                 SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: recentSearchData, forKey: UserDefaults.Keys.recentSearch)
             }
+            songDetailVC.musicId = recentSearchData[indexPath.row].id
         }
         
         fetchSearchResultData()
         
-        let songDetailVC = SongDetailVC()
         self.navigationController?.pushViewController(songDetailVC, animated: true)
         print("songDetailVC")
     }

--- a/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
@@ -57,6 +57,7 @@ class SearchVC: BaseVC {
                 searchResultEmptyView.isHidden = true
             case .searchResult:
                 recentSearchEmptyView.isHidden = true
+                self.allClearButton.isHidden = true
                 recentSearchTitleView.snp.updateConstraints {
                     $0.height.equalTo(0)
                 }
@@ -90,6 +91,7 @@ class SearchVC: BaseVC {
     private func fetchSearchResultData() {
         if let localData = SearchResultResponseModelElement.getSearchResultModelFromUserDefaults(forKey: UserDefaults.Keys.recentSearch) {
             recentSearchData = localData
+            recentSearchData.isEmpty ? closeRecentSearchTitleView() : openRecentSearchTitleView()
         } else {
             SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: [], forKey: UserDefaults.Keys.recentSearch)
             fetchSearchResultData()
@@ -305,6 +307,7 @@ extension SearchVC {
             $0.centerY.equalTo(recentSearchLabel)
             $0.trailing.equalToSuperview().inset(20)
             $0.width.equalTo(48.adjustedW)
+            $0.height.equalTo(16.adjustedW)
         }
     }
 }

--- a/MUMENT/MUMENT/Sources/Scenes/Write/SearchForWriteView.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Write/SearchForWriteView.swift
@@ -193,10 +193,11 @@ extension SearchForWriteView: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch searchTVType {
         case .recentSearch:
-            recentSearchData.append(recentSearchData[indexPath.row])
-            recentSearchData.remove(at: indexPath.row)
+            NotificationCenter.default.post(name: .sendSearchResult, object: recentSearchData.reversed()[indexPath.row])
+            recentSearchData.append(recentSearchData.reversed()[indexPath.row])
+            recentSearchData.remove(at: self.recentSearchData.count - indexPath.row - 2)
             SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: recentSearchData, forKey: UserDefaults.Keys.recentSearch)
-            NotificationCenter.default.post(name: .sendSearchResult, object: recentSearchData[indexPath.row])
+            
         case .searchResult:
             if recentSearchData.contains(searchResultData[indexPath.row]) {
                 recentSearchData.append(recentSearchData[indexPath.row])


### PR DESCRIPTION
## 🎸 작업한 내용

- [x] 기록하기 서치 최근검색 엠티뷰 이미지 비율 이상함(XS MAX)
- [x] 최근 검색 목록에서 select 했을 때 인덱스 거꾸로 뜨는 문제 해결
- [x] 서치 검색결과 -> 곡상세로 넘어갈 때 musicId 들어가도록 수정
- [x] 검색결과에서 다른거 네비로 이동했다가 돌아왔는데 모두삭제 버튼이 잘려서 나오는 문제 해결
- [x] 최근 검색 뷰가 기록하기 뷰에서 업데이트 됐을 때 갑분 엠티뷰가 뜨는 문제 해결


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone SE (2nd generation) - 2022-07-22 at 06 11 04](https://user-images.githubusercontent.com/43312096/180315896-ec366c0f-5bd4-4779-8529-aff99a20cf97.gif)

## 💽 관련 이슈
- Resolved: #104 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
