### PR TITLE
[FIX] 결과가 없는 태그 선택시 엠티뷰 연결

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
@@ -34,6 +34,10 @@ class LikedMumentVC: UIViewController {
     var dateDictionary : [Int : Int] = [:]
     var numberOfSections = 0
     
+    private let emptyView = StorageEmptyView().then {
+          $0.setLikedMumentLayout()
+      }
+    
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -132,9 +136,15 @@ extension LikedMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, U
         
         switch cellCategory {
         case .listCell:
-            listCell.setWithoutHeartCardUI()
+            
             
             if indexPath.section == 0 {
+                if indexPath.row > withoutHeartMumentData.count - 1{
+                    listCell.setEmptyCardView()
+                    likedMumentCV.reloadData()
+                    return listCell
+                }
+                listCell.setWithoutHeartCardUI()
                 listCell.setWithoutHeartCardData(withoutHeartMumentData[indexPath.row])
                 return listCell
             }
@@ -142,6 +152,7 @@ extension LikedMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, U
             for i in 0...indexPath.section-1{
                 mData += (dateDictionary[dateArray[i]])!
             }
+            listCell.setWithoutHeartCardUI()
             listCell.setWithoutHeartCardData(withoutHeartMumentData[mData + indexPath.row])
             return listCell
         case .albumCell:
@@ -194,6 +205,11 @@ extension LikedMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, U
                     as? SectionHeader else {
                 return UICollectionReusableView()
             }
+            if indexPath.row > withoutHeartMumentData.count - 1{
+                header.resetHeader()
+                setEmptyViewLayout() 
+                return header
+            }
             let year = dateArray[indexPath.section] / 100
             let month = dateArray[indexPath.section] % 10
             header.setHeader(year, month)
@@ -223,6 +239,14 @@ extension LikedMumentVC {
         likedMumentCV.snp.makeConstraints{
             $0.leading.trailing.equalToSuperview()
             $0.top.bottom.equalToSuperview()
+        }
+    }
+    
+    func setEmptyViewLayout() {
+        likedMumentCV.removeFromSuperview()
+        view.addSubviews([emptyView])
+        emptyView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
@@ -66,8 +66,6 @@ class LikedMumentVC: UIViewController {
         tagButtton.forEach {
             if let title = $0.titleLabel?.text {
                 selectedTagsInt.append(title.tagInt() ?? 0)
-                debugPrint("타이틀", title)
-                debugPrint("프린트", title.tagInt() ?? 0)
             }
         }
          getLikedMumentStorage(userId: UserInfo.shared.userId ?? "", filterTags: selectedTagsInt)

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/ListCVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/ListCVC.swift
@@ -16,6 +16,7 @@ class ListCVC: UICollectionViewCell {
     
     private let defaultCardView = DefaultMumentCardView()
     private let withoutHeartCardView = MumentCardWithoutHeartView()
+    private let storageEmptyView = StorageEmptyView()
     
     // MARK: - Initialization
     override init(frame: CGRect) {
@@ -45,6 +46,13 @@ class ListCVC: UICollectionViewCell {
 //        }
         self.addSubviews([withoutHeartCardView])
         withoutHeartCardView.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func setEmptyCardView() {
+        self.addSubviews([storageEmptyView])
+        storageEmptyView.snp.makeConstraints{
             $0.edges.equalToSuperview()
         }
     }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
@@ -34,6 +34,11 @@ class MyMumentVC: UIViewController {
     var dateDictionary : [Int : Int] = [:]
     var numberOfSections = 0
     
+    private let emptyView = StorageEmptyView().then {
+           $0.setMyMumentLayout()
+       }
+    
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setCollectionView()
@@ -85,6 +90,7 @@ class MyMumentVC: UIViewController {
             
             defaultMumentData.forEach {
                 date = $0.year * 100 + $0.month
+                debugPrint("데이트",date)
                 dates.append(date)
                 dateDictionary[date] = 0
             }
@@ -109,6 +115,7 @@ class MyMumentVC: UIViewController {
         } else {
             numberOfSections = 1
         }
+        debugPrint("데이트어레이",dateArray.count)
     }
 }
 
@@ -134,7 +141,14 @@ extension MyMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, UICo
         case .listCell:
             listCell.setDefaultCardUI()
             
+            debugPrint("뮤멘트카운트",defaultMumentData.count)
+            
             if indexPath.section == 0 {
+                if indexPath.row > defaultMumentData.count - 1{
+                    listCell.setEmptyCardView()
+                    myMumentCV.reloadData()
+                    return listCell
+                }
                 listCell.setDefaultCardData(defaultMumentData[indexPath.row])
                 return listCell
             }
@@ -192,6 +206,15 @@ extension MyMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, UICo
                     as? SectionHeader else {
                 return UICollectionReusableView()
             }
+            if indexPath.row > defaultMumentData.count - 1{
+                header.resetHeader()
+                setEmptyViewLayout()
+                // 기록하기 버튼 클릭시 이동
+                emptyView.writeButton.press {
+                    self.tabBarController?.selectedIndex = 1
+                }
+                return header
+            }
             let year = dateArray[indexPath.section] / 100
             let month = dateArray[indexPath.section] % 10
             header.setHeader(year, month)
@@ -222,6 +245,14 @@ extension MyMumentVC {
         myMumentCV.snp.makeConstraints{
             $0.leading.trailing.equalToSuperview()
             $0.top.bottom.equalToSuperview()
+        }
+    }
+    
+    func setEmptyViewLayout() {
+        myMumentCV.removeFromSuperview()
+        view.addSubviews([emptyView])
+        emptyView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
@@ -202,13 +202,14 @@ extension MyMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, UICo
             }
             if indexPath.row > defaultMumentData.count - 1{
                 header.resetHeader()
-                setEmptyViewLayout()
-                // 기록하기 버튼 클릭시 이동
+                /// 기록하기 버튼 클릭시 이동
+                emptyView.isHidden = false
                 emptyView.writeButton.press {
                     self.tabBarController?.selectedIndex = 1
                 }
                 return header
             }
+            emptyView.isHidden = true
             let year = dateArray[indexPath.section] / 100
             let month = dateArray[indexPath.section] % 10
             header.setHeader(year, month)
@@ -235,19 +236,18 @@ extension MyMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, UICo
 extension MyMumentVC { 
     
     func setUILayout() {
-        view.addSubViews([myMumentCV])
+        view.addSubViews([myMumentCV, emptyView])
         myMumentCV.snp.makeConstraints{
             $0.leading.trailing.equalToSuperview()
             $0.top.bottom.equalToSuperview()
         }
-    }
-    
-    func setEmptyViewLayout() {
-        myMumentCV.removeFromSuperview()
+        
         view.addSubviews([emptyView])
         emptyView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+        
+        emptyView.isHidden = true
     }
 }
 // MARK: - Network

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
@@ -68,8 +68,6 @@ class MyMumentVC: UIViewController {
         tagButtton.forEach {
             if let title = $0.titleLabel?.text {
                 selectedTagsInt.append(title.tagInt() ?? 0)
-                debugPrint("타이틀", title)
-                debugPrint("프린트", title.tagInt() ?? 0)
             }
         }
         getMyMumentStorage(userId: UserInfo.shared.userId ?? "", filterTags: selectedTagsInt)
@@ -90,7 +88,6 @@ class MyMumentVC: UIViewController {
             
             defaultMumentData.forEach {
                 date = $0.year * 100 + $0.month
-                debugPrint("데이트",date)
                 dates.append(date)
                 dateDictionary[date] = 0
             }
@@ -115,7 +112,6 @@ class MyMumentVC: UIViewController {
         } else {
             numberOfSections = 1
         }
-        debugPrint("데이트어레이",dateArray.count)
     }
 }
 
@@ -140,9 +136,7 @@ extension MyMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, UICo
         switch cellCategory {
         case .listCell:
             listCell.setDefaultCardUI()
-            
-            debugPrint("뮤멘트카운트",defaultMumentData.count)
-            
+                        
             if indexPath.section == 0 {
                 if indexPath.row > defaultMumentData.count - 1{
                     listCell.setEmptyCardView()

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/SectionHeader.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/SectionHeader.swift
@@ -44,7 +44,9 @@ extension SectionHeader {
             $0.left.equalToSuperview().inset(20)
             $0.right.top.bottom.equalToSuperview()
         }
-        
     }
     
+    func resetHeader() {
+        self.removeFromSuperview()
+    }
 }


### PR DESCRIPTION
## 🎸 작업한 내용
- 검색 결과가 없는 태그 선택시 앱이 터지지 않도록 분기처리를 해주고, 엠티뷰를 연결함

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 현재 엠티뷰를 띄우는 방식이 기존의 뷰를 제거하고, emptyView를 add하여 띄우는거라 
  엠티뷰가 나온 이후 다른 태그 검색시 결과 뷰가 뜨지 않는 문제가 있는데 우선 엠티뷰 띄우는 것 까지만 PR올립니다.
 해당 부분은 고민해보고 해결할거지만 피드백 주시면 반영해서 해보겠습니다~

- 기록하기로 넘어가는게 songDetailVC에서 탭바만 전환하는걸로 되어있어 같은 방식을 적용했는데 이런식으로 한는게 괜찮을지 피드백도 환영합니다~~

- 아요 회고 하고해열~~

## 📸 스크린샷
<-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2022-07-25 at 14 03 32](https://user-images.githubusercontent.com/32871014/180703209-f89c5102-fe94-4cf7-9b90-480e5c86874c.gif)
!

## 💽 관련 이슈
- Resolved: #이슈번호

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
