### PR TITLE
[FIX] 태그 필터 관련 UI 및 로직 수정

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Storage/AlbumCVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/AlbumCVC.swift
@@ -13,7 +13,9 @@ class AlbumCVC: UICollectionViewCell {
 
     let mumentAlbumView = UIImageView()
     
-    
+    private let defaultCardView = DefaultMumentCardView()
+    private let withoutHeartCardView = MumentCardWithoutHeartView()
+    private let storageEmptyView = StorageEmptyView()
     
     // MARK: - Initialization
     override init(frame: CGRect) {
@@ -36,9 +38,35 @@ class AlbumCVC: UICollectionViewCell {
     
     func fetchData(_ cellData: GetLikedMumentResponseModel.Mument) {
         mumentAlbumView.setImageUrl(cellData.music.image ?? "https://mument.s3.ap-northeast-2.amazonaws.com/user/emptyImage.jpg")
+        debugPrint("좋아요한 뮤멘트 이미지 fetch")
     }
     
     func fetchData(_ cellData: GetMyMumentResponseModel.Mument) {
         mumentAlbumView.setImageUrl(cellData.music.image ?? "https://mument.s3.ap-northeast-2.amazonaws.com/user/emptyImage.jpg")
     }
+    
+    func setWithoutHeartCardUI() {
+        self.addSubviews([withoutHeartCardView])
+        withoutHeartCardView.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func setWithoutHeartCardData(_ cellData: GetLikedMumentResponseModel.Mument) {
+        withoutHeartCardView.setData(cellData)
+    }
+    
+    func setEmptyCardView() {
+        self.addSubviews([storageEmptyView])
+        storageEmptyView.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    func setDefaultCardData(_ cellData:GetMyMumentResponseModel.Mument) {
+    //        defaultCardView.setData(defaultData[0])
+        defaultCardView.setData(cellData)
+    }
 }
+
+

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/AlbumCVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/AlbumCVC.swift
@@ -38,7 +38,6 @@ class AlbumCVC: UICollectionViewCell {
     
     func fetchData(_ cellData: GetLikedMumentResponseModel.Mument) {
         mumentAlbumView.setImageUrl(cellData.music.image ?? "https://mument.s3.ap-northeast-2.amazonaws.com/user/emptyImage.jpg")
-        debugPrint("좋아요한 뮤멘트 이미지 fetch")
     }
     
     func fetchData(_ cellData: GetMyMumentResponseModel.Mument) {

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
@@ -155,6 +155,11 @@ extension LikedMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, U
             return listCell
         case .albumCell:
             if indexPath.section == 0 {
+                if indexPath.row > withoutHeartMumentData.count - 1{
+                    albumCell.setEmptyCardView()
+                    likedMumentCV.reloadData()
+                    return albumCell
+                }
                 albumCell.fetchData(withoutHeartMumentData[indexPath.row])
                 return albumCell
             }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
@@ -82,7 +82,7 @@ class LikedMumentVC: UIViewController {
         var dates: [Int] = []
         var date = 0
         
-        if withoutHeartMumentData.count != 1 {
+        if withoutHeartMumentData.count != 0 {
             
             withoutHeartMumentData.forEach {
                 date = $0.year * 100 + $0.month
@@ -208,7 +208,7 @@ extension LikedMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, U
                     as? SectionHeader else {
                 return UICollectionReusableView()
             }
-            if indexPath.row > withoutHeartMumentData.count - 1{
+            if withoutHeartMumentData.count == 0{
                 header.resetHeader()
                 setEmptyViewLayout() 
                 return header

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/ListCVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/ListCVC.swift
@@ -41,9 +41,6 @@ class ListCVC: UICollectionViewCell {
     }
     
     func setWithoutHeartCardUI() {
-//        for view in self.subviews {
-//            view.removeFromSuperview()
-//        }
         self.addSubviews([withoutHeartCardView])
         withoutHeartCardView.snp.makeConstraints{
             $0.edges.equalToSuperview()
@@ -58,7 +55,6 @@ class ListCVC: UICollectionViewCell {
     }
     
     func setWithoutHeartCardData(_ cellData: GetLikedMumentResponseModel.Mument) {
-        debugPrint("setWithoutHeartCardData")
         withoutHeartCardView.setData(cellData)
     }
 }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/Model/TagButton.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/Model/TagButton.swift
@@ -19,7 +19,7 @@ class TagButton: UIButton {
         self.setImage(UIImage(named: "mumentTagDelete"), for: .normal)
         self.contentHorizontalAlignment = .center
         self.configuration = .plain()
-        self.configuration?.imagePadding = 10.adjustedH
+        self.configuration?.imagePadding = 5.adjustedH
         self.configuration?.imagePlacement = .trailing
         self.attributedTitle(for: .normal)
     }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
@@ -154,6 +154,11 @@ extension MyMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, UICo
             return listCell
         case .albumCell:
             if indexPath.section == 0 {
+                if indexPath.row > defaultMumentData.count - 1{
+                    albumCell.setEmptyCardView()
+                    myMumentCV.reloadData()
+                    return albumCell
+                }
                 albumCell.fetchData(defaultMumentData[indexPath.row])
                 return albumCell
             }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
@@ -84,7 +84,7 @@ class MyMumentVC: UIViewController {
         var dates: [Int] = []
         var date = 0
         
-        if defaultMumentData.count != 1 {
+        if defaultMumentData.count != 0 {
             
             defaultMumentData.forEach {
                 date = $0.year * 100 + $0.month
@@ -205,7 +205,7 @@ extension MyMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, UICo
                     as? SectionHeader else {
                 return UICollectionReusableView()
             }
-            if indexPath.row > defaultMumentData.count - 1{
+            if defaultMumentData.count == 0 {
                 header.resetHeader()
                 /// 기록하기 버튼 클릭시 이동
                 emptyView.isHidden = false

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageBottomSheet.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageBottomSheet.swift
@@ -182,7 +182,6 @@ class StorageBottomSheet: BaseVC {
         let filterTagButton = TagButton()
         selectedTagButtons.append(filterTagButton)
         selectedTagButtons[count].setTagButtonTitle(tagTitle)
-        self.setFilterTagButton.layoutIfNeeded()
     }
     
     private func setAllDeselectAction() {
@@ -373,10 +372,10 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
             }
             self.selectedTagsStackView.layoutIfNeeded()
             
+            // 방금 추가된 선택 버튼 클릭시 컬렉션 뷰에서도 deselect되도록 설정
             selectedTagButtons.last?.press {
                 self.collectionView(collectionView, didDeselectItemAt: indexPath)
                 collectionView.deselectItem(at: indexPath, animated: false)
-                
             }
 
         }else {
@@ -407,8 +406,8 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
                 self.selectedTagsStackView.removeArrangedSubview($0)
                 $0.removeFromSuperview()
             }
-            selectedTagButtons.remove(at: selectedTagDictionay[indexPath.row]!)
-            tagIndex.remove(at: selectedTagDictionay[indexPath.row]!)
+            selectedTagButtons.remove(at: selectedTagDictionay[indexPath.row] ?? 0)
+            tagIndex.remove(at: selectedTagDictionay[indexPath.row] ?? 0)
             
         case feelTagCV:
             
@@ -420,9 +419,8 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
                 self.selectedTagsStackView.removeArrangedSubview($0)
                 $0.removeFromSuperview()
             }
-//            selectedTagButtons[selectedTagDictionay[indexPath.row + 100]!].removeTarget(nil, action: nil, for: .allEvents)
-            selectedTagButtons.remove(at: selectedTagDictionay[indexPath.row + 100]!)
-            tagIndex.remove(at: selectedTagDictionay[indexPath.row + 100]!)
+            selectedTagButtons.remove(at: selectedTagDictionay[indexPath.row + 100] ?? 0)
+            tagIndex.remove(at: selectedTagDictionay[indexPath.row + 100] ?? 0)
             
         default: break
         }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageBottomSheet.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageBottomSheet.swift
@@ -100,7 +100,7 @@ class StorageBottomSheet: BaseVC {
         $0.sectionInset = .zero
     }
     
-    private let setFilterTagButton = UIButton().then {
+    private let tagAppliedButton = UIButton().then {
         $0.setTitle("태그 적용하기", for: .normal)
         $0.titleLabel?.font = UIFont.mumentB2B14
         $0.setTitleColor(UIColor.mWhite, for: .normal)
@@ -142,6 +142,7 @@ class StorageBottomSheet: BaseVC {
         setTagCV()
         registerCell()
         setFilterTagLayout()
+        
         setAllDeselectAction()
         setFilterTagApplied()
         
@@ -205,7 +206,7 @@ class StorageBottomSheet: BaseVC {
     }
     
     private func setFilterTagApplied() {
-        setFilterTagButton.press {
+        tagAppliedButton.press {
             self.delegate?.sendButtonData(data: self.selectedTagButtons)
             self.hideBottomSheetWithAnimation()
         }
@@ -354,14 +355,14 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
             switch collectionView {
             case impressionTagCV:
                 buttonAppend(selectedTagCount - 1, impressionTagData[indexPath.row])
-                // key가 태그 번호, value가 선택된 태그 인덱스 번호 0, 1, 2
+                /// key가 태그 번호, value가 선택된 태그 인덱스 번호 0, 1, 2
                 selectedTagDictionay[indexPath.row] = selectedTagCount - 1
                 
                 tagIndex.append(indexPath.row)
                 
             case feelTagCV:
                 buttonAppend(selectedTagCount - 1, feelTagData[indexPath.row])
-                // impressionTag번호와 다르게 구분하기 위해 + 100
+                /// impressionTag번호와 다르게 구분하기 위해 + 100
                 selectedTagDictionay[indexPath.row + 100] = selectedTagCount - 1
                 
                 tagIndex.append(indexPath.row + 100)
@@ -380,21 +381,6 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
                 $0.snp.makeConstraints {
                     $0.height.equalTo(35)
                 }
-                
-                /// 스택뷰가 길어지는거 방지
-                if self.selectedTagButtons.count == 3 {
-                    self.selectedTagsStackView.snp.makeConstraints {
-                        $0.left.right.equalTo(selectedTagsSection).inset(5)
-                    }
-                }else {
-                    self.selectedTagsStackView.snp.removeConstraints()
-                    selectedTagsStackView.snp.makeConstraints {
-                        $0.left.equalToSuperview().inset(10)
-                        $0.top.equalTo(selectedTagsSection).offset(14.adjustedH)
-                        $0.height.equalTo(tagCellHeight)
-                    }
-                }
-
             }
             self.selectedTagsStackView.layoutIfNeeded()
             
@@ -450,13 +436,6 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
         tagIndex.forEach {
             selectedTagDictionay[$0] = count
             count += 1
-        }
-        
-        self.selectedTagsStackView.snp.removeConstraints()
-        selectedTagsStackView.snp.makeConstraints {
-            $0.left.equalToSuperview().inset(10)
-            $0.top.equalTo(selectedTagsSection).offset(14.adjustedH)
-            $0.height.equalTo(tagCellHeight)
         }
         
         selectedTagButtons.forEach {
@@ -545,30 +524,44 @@ extension StorageBottomSheet {
     }
     
     func setBottomLayout() {
-        containerView.addSubViews([setFilterTagButton, allDeselecteButton, selectedTagsSection, selectedTagsStackView])
+        containerView.addSubViews([tagAppliedButton, allDeselecteButton, selectedTagsSection, selectedTagsStackView])
         
-        setFilterTagButton.snp.makeConstraints {
-            $0.top.equalTo(feelTagCV.snp.bottom).offset(15.adjustedH)
-            $0.right.equalToSuperview().inset(20)
-            $0.width.equalTo(143)
-            $0.height.equalTo(45.adjustedH)
-        }
-        
-        allDeselecteButton.snp.makeConstraints {
-            $0.left.equalToSuperview().inset(19)
-            $0.centerY.equalTo(setFilterTagButton)
-            $0.height.equalTo(26)
+        if UIScreen.main.bounds.width >= 375 {
+            tagAppliedButton.snp.makeConstraints {
+                $0.top.equalTo(feelTagCV.snp.bottom).offset(15.adjustedH)
+                $0.right.equalToSuperview().inset(20)
+                $0.width.equalTo(143)
+                $0.height.equalTo(45.adjustedH)
+            }
+            
+            allDeselecteButton.snp.makeConstraints {
+                $0.left.equalToSuperview().inset(19)
+                $0.centerY.equalTo(tagAppliedButton)
+                $0.height.equalTo(26)
+            }
+        }else {
+            tagAppliedButton.snp.makeConstraints {
+                $0.top.equalTo(feelTagCV.snp.bottom)
+                $0.right.equalToSuperview().inset(20)
+                $0.width.equalTo(143)
+                $0.height.equalTo(45.adjustedH)
+            }
+            
+            allDeselecteButton.snp.makeConstraints {
+                $0.left.equalToSuperview().inset(19)
+                $0.centerY.equalTo(tagAppliedButton)
+                $0.height.equalTo(26)
+            }
         }
     }
     func setFilterTagLayout() {
         selectedTagsSection.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
-            $0.top.equalTo(setFilterTagButton.snp.bottom).offset(20.adjustedH)
+            $0.top.equalTo(tagAppliedButton.snp.bottom).offset(20.adjustedH)
             $0.height.equalTo(bottomTagSectionHeight)
         }
-        
         selectedTagsStackView.snp.makeConstraints {
-            $0.left.equalToSuperview().inset(20)
+            $0.left.equalToSuperview().inset(10)
             $0.top.equalTo(selectedTagsSection).offset(14.adjustedH)
             $0.height.equalTo(tagCellHeight)
         }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageBottomSheet.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageBottomSheet.swift
@@ -201,7 +201,6 @@ class StorageBottomSheet: BaseVC {
                     $0.height.equalTo(0)
                 }
             }
-            
         }
     }
     
@@ -267,7 +266,19 @@ extension StorageBottomSheet {
             }
             self.view.layoutIfNeeded()
         }
+        //TODO: 바텀시트 하단 선택 태그 UI 업데이트
+        selectedTagButtons.forEach {
+            self.selectedTagsStackView.removeArrangedSubview($0)
+        }
         
+        selectedTagButtons.forEach {
+            self.selectedTagsStackView.addArrangedSubview($0)
+            
+            $0.snp.makeConstraints {
+                $0.height.equalTo(35)
+            }
+        }
+        self.selectedTagsStackView.layoutIfNeeded()
     }
     
     func hideBottomSheetWithAnimation() {
@@ -365,14 +376,29 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
             
             selectedTagButtons.forEach {
                 self.selectedTagsStackView.addArrangedSubview($0)
-                
+                                
                 $0.snp.makeConstraints {
                     $0.height.equalTo(35)
                 }
+                
+                /// 스택뷰가 길어지는거 방지
+                if self.selectedTagButtons.count == 3 {
+                    self.selectedTagsStackView.snp.makeConstraints {
+                        $0.left.right.equalTo(selectedTagsSection).inset(5)
+                    }
+                }else {
+                    self.selectedTagsStackView.snp.removeConstraints()
+                    selectedTagsStackView.snp.makeConstraints {
+                        $0.left.equalToSuperview().inset(10)
+                        $0.top.equalTo(selectedTagsSection).offset(14.adjustedH)
+                        $0.height.equalTo(tagCellHeight)
+                    }
+                }
+
             }
             self.selectedTagsStackView.layoutIfNeeded()
             
-            // 방금 추가된 선택 버튼 클릭시 컬렉션 뷰에서도 deselect되도록 설정
+            /// 방금 추가된 선택 버튼 클릭시 컬렉션 뷰에서도 deselect되도록 설정
             selectedTagButtons.last?.press {
                 self.collectionView(collectionView, didDeselectItemAt: indexPath)
                 collectionView.deselectItem(at: indexPath, animated: false)
@@ -380,7 +406,6 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
 
         }else {
             collectionView.deselectItem(at: indexPath, animated: false)
-            // TODO: 3개 제한 토스트 창 삽입
             self.showToastMessage(message: "태그는 최대 3개까지 선택할 수 있어요.")
             
         }
@@ -410,15 +435,11 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
             tagIndex.remove(at: selectedTagDictionay[indexPath.row] ?? 0)
             
         case feelTagCV:
-            
             selectedTagButtons.forEach {
                 self.selectedTagsStackView.removeArrangedSubview($0)
                 $0.removeFromSuperview()
             }
-            selectedTagButtons.forEach {
-                self.selectedTagsStackView.removeArrangedSubview($0)
-                $0.removeFromSuperview()
-            }
+
             selectedTagButtons.remove(at: selectedTagDictionay[indexPath.row + 100] ?? 0)
             tagIndex.remove(at: selectedTagDictionay[indexPath.row + 100] ?? 0)
             
@@ -431,6 +452,13 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
             count += 1
         }
         
+        self.selectedTagsStackView.snp.removeConstraints()
+        selectedTagsStackView.snp.makeConstraints {
+            $0.left.equalToSuperview().inset(10)
+            $0.top.equalTo(selectedTagsSection).offset(14.adjustedH)
+            $0.height.equalTo(tagCellHeight)
+        }
+        
         selectedTagButtons.forEach {
             self.selectedTagsStackView.addArrangedSubview($0)
             
@@ -438,6 +466,7 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
                 $0.height.equalTo(35)
             }
         }
+        
         
         self.selectedTagsStackView.layoutIfNeeded()
         

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
@@ -178,6 +178,8 @@ class StorageVC: BaseVC {
                 self.present(self.storageBottomSheet, animated: false) {
                     self.storageBottomSheet.showBottomSheetWithAnimation()
                 }
+                
+                // TODO: 필터 버튼 활성 표시 수정
                 self.filterButton.isSelected = !self.storageBottomSheet.isDismissed
             }
         }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
@@ -118,7 +118,15 @@ class StorageVC: BaseVC {
     }
     
     /// StorageBottomSheet에서 전달 받은 태그 버튼 배열
-    var selectedTagButtons = [TagButton]()
+    var selectedTagButtons = [TagButton]() {
+        didSet {
+            if self.selectedTagButtons.count == 0 {
+                self.filterButton.isSelected = false
+            }else {
+                self.filterButton.isSelected = true
+            }
+        }
+    }
     
     private let selectedTagsStackView = UIStackView().then {
         $0.backgroundColor = .clear
@@ -171,16 +179,9 @@ class StorageVC: BaseVC {
     
     private func setPressAction() {
         filterButton.press {
-            self.filterButton.isSelected.toggle()
-            
-            if self.filterButton.isSelected {
-                self.storageBottomSheet.modalPresentationStyle = .overFullScreen
-                self.present(self.storageBottomSheet, animated: false) {
-                    self.storageBottomSheet.showBottomSheetWithAnimation()
-                }
-                
-                // TODO: 필터 버튼 활성 표시 수정
-                self.filterButton.isSelected = !self.storageBottomSheet.isDismissed
+            self.storageBottomSheet.modalPresentationStyle = .overFullScreen
+            self.present(self.storageBottomSheet, animated: false) {
+                self.storageBottomSheet.showBottomSheetWithAnimation()
             }
         }
         
@@ -249,6 +250,8 @@ class StorageVC: BaseVC {
 // MARK: - Protocol
 extension StorageVC: storageBottomSheetDelegate {
     func sendButtonData(data: [TagButton]) {
+        
+        
         selectedTagButtons = data
 
         selectedTagButtons.forEach { button in
@@ -389,8 +392,7 @@ extension StorageVC {
         selectedTagsView.addSubviews([selectedTagsStackView])
         
         selectedTagsStackView.snp.makeConstraints{
-//            $0.top.equalTo(selectedTagsView).offset(5)
-            $0.leading.equalToSuperview().inset(20)
+            $0.leading.equalToSuperview().inset(10)
             $0.height.equalTo(35)
             $0.centerY.equalTo(selectedTagsView)
         }

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
@@ -207,28 +207,16 @@ class StorageVC: BaseVC {
     }
     
     func showSelectedTagsView() {
-        // TODO: 필터 적용 버튼 클릭시로 수정
         if selectedTagButtons.count != 0 {
             self.tagsViewHeightConstant = 49
             
             selectedTagButtons.forEach {
                 self.selectedTagsStackView.addArrangedSubview($0)
-                debugPrint("foreach")
                 
                 $0.snp.makeConstraints {
                     $0.height.equalTo(35)
                 }
             }
-            
-//            for i in 0...selectedTagButtons.count - 1 {
-//                selectedTagButtons[i].press {
-//                    selectedTagButtons[i].isSelected.toggle()
-//                    if selectedTagButtons[i].isSelected == false {
-//                        self.selectedTagsStackView.removeArrangedSubview($0)
-//                        selectedTagButtons[i].removeFromSuperview()
-//                    }
-//                }
-//            }
                         
         }else {
             self.tagsViewHeightConstant = 0
@@ -258,6 +246,22 @@ class StorageVC: BaseVC {
 extension StorageVC: storageBottomSheetDelegate {
     func sendButtonData(data: [TagButton]) {
         selectedTagButtons = data
+
+        selectedTagButtons.forEach { button in
+            button.press {
+                var tempButtons = [TagButton]()
+                
+                self.selectedTagButtons.forEach { thisButton in
+                    if thisButton == button {}
+                    else {
+                        tempButtons.append(thisButton)
+                    }
+                }
+                self.selectedTagButtons = tempButtons
+                self.selectedTagsStackView.removeAllArrangedSubviews()
+                self.showSelectedTagsView()
+            }
+        }
         showSelectedTagsView()
     }
 }
@@ -397,24 +401,3 @@ extension StorageVC {
     }
     
 }
-
-//// MARK: - Network
-//extension StorageVC {
-//  private func getMyMumentStorage(userId: String, filterTags: [Int]) {
-//    StorageAPI.shared.getMyMumentStorage(userId: userId, filterTags: filterTags) { networkResult in
-//      switch networkResult {
-//      case .success(let response):
-//        if let result = response as? GetMyMumentStorageResponseModel {
-//            print(result.muments[0])
-//        } else {
-//          debugPrint("🚨당신 모델이 이상해열~🚨")
-//        }
-//      default:
-//        self.makeAlert(title: """
-//네트워크 오류로 인해 연결에 실패했어요! 😢
-//잠시 후에 다시 시도해 주세요.
-//""")
-//      }
-//    }
-//  }
-//}

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
@@ -226,6 +226,8 @@ class StorageVC: BaseVC {
             $0.height.equalTo(self.tagsViewHeightConstant)
         }
         
+        self.selectedTagsView.layoutIfNeeded()
+        
         likedMumentVC.setTagsTitle(selectedTagButtons)
         myMumentVC.setTagsTitle(selectedTagButtons)
     }
@@ -259,6 +261,7 @@ extension StorageVC: storageBottomSheetDelegate {
                 }
                 self.selectedTagButtons = tempButtons
                 self.selectedTagsStackView.removeAllArrangedSubviews()
+                
                 self.showSelectedTagsView()
             }
         }


### PR DESCRIPTION
## 🎸 작업한 내용
기존 태그 필터 관련 에러 사항 수정
- 보관함 탭에서 선택된 태그별 삭제시 에러 (태그 클릭시 전체 태그가 사라지고 뒤 배경 뷰는 남아있었음) -> 아래 PR포인트 3번 내용 방법 사용
- 보관함 탭에서 태그 삭제시 바텀시트 내 선택된 태그에 제대로 반영이 되지 않는 에러 ->  아래 PR포인트 3번 내용 방법 사용
- 4글자 태그 2개(여유로움, 스트레스) 포함한 3개의 태그 선택시 태그 버튼 스택뷰가 길어져 화면을 넘어가는 에러 -> 버튼 자체 패딩 줄이고스택뷰 왼쪽 constraint를 줄였음
- 필터 버튼 isSelected 상태가 제멋대로인 에러 -> 선택된 태그 카운트 수를 옵저버 하도록 didSet사용해서 선택된 버튼이 있을 경우만 selected 상태

기타 에러
- 검색 결과가 1개 셀 밖에 없을 때 날짜가 잘 못 나오는 에러 (분기처리 실수)

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 태그 스택뷰 길어지는 문제를 처음에는 스택뷰 길이를 구해서 뒤에 컨테이너 뷰하고 비교 및 분기처리해서 스택뷰가 길어질때 오른쪽 inset을 추가하는 식으로 처리 하려고 했는데 스택뷰의 frame.width를 찍어보니 스택뷰가 보기에 화면을 넘어가 보여도 width 값은 그만큰 안 길어지는 것을 확인해 해당 방법을 적용하기 애매한 부분이 있었는데 이와 관련해서 의견 환영입니다.

- 이유는 아직 모르겠는데 태그 버튼 스택뷰 삭제가 잘 되다가 계속 써보다보면 UI 상으로 한번에 2개가 삭제가 되는 경우가 발생하는데 혹시 이와 관련하여 이상한 점 발견하시면 피드백 부탁합니당;;

- 버튼 스택뷰에서 버튼 클릭시 버튼이 삭제가 되는것을 구현하기 위해 스택뷰에 버튼 클릭시 스택뷰에 있는거를 다 지우고 클릭된 버튼을 제외한 나머지를 다시 스택뷰에 넣어주는 방법으로 구현을 했는데 더 좋은 방법이 있다면 피드백 바랍니다!

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
|    기존 뷰    |  수정 뷰  |
| :-------------:   |   :-------------: 
![Simulator Screen Recording - iPhone 13 mini - 2022-08-15 at 00 19 34](https://user-images.githubusercontent.com/32871014/184545397-d3f69959-9e87-4a29-bb96-b2659241006a.gif) |  ![Simulator Screen Recording - iPhone 13 mini - 2022-08-15 at 00 44 39](https://user-images.githubusercontent.com/32871014/184545459-3736056f-73c4-4fc8-ad8f-a068a7dfa6dc.gif)


## 💽 관련 이슈 
- Resolved: #130 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
