### PR TITLE
[FEAT] 빨간색 토스트 메시지 구현

### DIFF
--- a/MUMENT/MUMENT.xcodeproj/project.pbxproj
+++ b/MUMENT/MUMENT.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		C71B48162886E5DF001A7CD6 /* SignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71B48152886E5DF001A7CD6 /* SignInVC.swift */; };
 		C71B48182886E7BA001A7CD6 /* SignInDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71B48172886E7BA001A7CD6 /* SignInDataModel.swift */; };
 		C71B481A2886F5FF001A7CD6 /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71B48192886F5FF001A7CD6 /* Int+.swift */; };
+		C73CBCFC291549ED009E9A40 /* ToastMessageColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73CBCFB291549ED009E9A40 /* ToastMessageColorType.swift */; };
 		C73FC9B4287AEA510017F2DA /* MumentCompleteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73FC9B3287AEA510017F2DA /* MumentCompleteButton.swift */; };
 		C73FC9C0287C19A40017F2DA /* TargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73FC9BF287C19A40017F2DA /* TargetType.swift */; };
 		C73FC9C2287C19B00017F2DA /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73FC9C1287C19B00017F2DA /* NetworkResult.swift */; };
@@ -246,6 +247,7 @@
 		C71B48152886E5DF001A7CD6 /* SignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInVC.swift; sourceTree = "<group>"; };
 		C71B48172886E7BA001A7CD6 /* SignInDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInDataModel.swift; sourceTree = "<group>"; };
 		C71B48192886F5FF001A7CD6 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
+		C73CBCFB291549ED009E9A40 /* ToastMessageColorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMessageColorType.swift; sourceTree = "<group>"; };
 		C73FC9B3287AEA510017F2DA /* MumentCompleteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentCompleteButton.swift; sourceTree = "<group>"; };
 		C73FC9BF287C19A40017F2DA /* TargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetType.swift; sourceTree = "<group>"; };
 		C73FC9C1287C19B00017F2DA /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
@@ -800,6 +802,7 @@
 			isa = PBXGroup;
 			children = (
 				C7DE6F53290ECE61002B9048 /* MessageType.swift */,
+				C73CBCFB291549ED009E9A40 /* ToastMessageColorType.swift */,
 			);
 			path = Type;
 			sourceTree = "<group>";
@@ -1021,6 +1024,7 @@
 				4D64A9E8287D810000450FCA /* MumentCardWithoutHeartView.swift in Sources */,
 				4D9734F3287F3A41003EF546 /* Preview.swift in Sources */,
 				4D13A6742888735800197D2A /* MumentDetailResponseModel.swift in Sources */,
+				C73CBCFC291549ED009E9A40 /* ToastMessageColorType.swift in Sources */,
 				C71B48122886DD29001A7CD6 /* SignInBodyModel.swift in Sources */,
 				C71B4807288597ED001A7CD6 /* SearchBottomSheetVC.swift in Sources */,
 				4D13A66A2887FD9300197D2A /* MumentDetailAPI.swift in Sources */,

--- a/MUMENT/MUMENT/Global/Extensions/UIViewController+.swift
+++ b/MUMENT/MUMENT/Global/Extensions/UIViewController+.swift
@@ -155,10 +155,21 @@ extension UIViewController {
     ///   - vc: 토스트 메시지가 띄워질 view controller
     func showToastMessage(message: String, color: ToastMessageColorType) {
         let width = 335.adjustedW
-        let toastLabel = UILabel(frame: CGRect(x: self.view.frame.size.width / 2 - CGFloat(width) / 2, y: 675.adjustedH, width: CGFloat(width), height: 40))
+        var frame = CGRect()
+        let toastLabel = UILabel()
         
-        toastLabel.backgroundColor = UIColor.mBlack2
-        toastLabel.textColor = UIColor.mWhite
+        switch color {
+        case .black:
+            toastLabel.backgroundColor = .mBlack2
+            toastLabel.textColor =  .mWhite
+            frame = CGRect(x: self.view.frame.size.width / 2 - CGFloat(width) / 2, y: 675.adjustedH, width: CGFloat(width), height: 40)
+        case .red:
+            toastLabel.backgroundColor = .mRed.withAlphaComponent(0.4)
+            toastLabel.textColor = .mBlack1
+            frame = CGRect(x: self.view.frame.size.width / 2 - CGFloat(width) / 2, y: 107.adjustedH, width: CGFloat(width), height: 40)
+        }
+        
+        toastLabel.frame = frame
         toastLabel.font = UIFont.mumentB8M12
         toastLabel.textAlignment = .center
         toastLabel.text = message

--- a/MUMENT/MUMENT/Global/Extensions/UIViewController+.swift
+++ b/MUMENT/MUMENT/Global/Extensions/UIViewController+.swift
@@ -153,7 +153,7 @@ extension UIViewController {
     ///- parameters:
     ///   - message: 화면에 보여질 메시지
     ///   - vc: 토스트 메시지가 띄워질 view controller
-    func showToastMessage(message : String) {
+    func showToastMessage(message: String, color: ToastMessageColorType) {
         let width = 335.adjustedW
         let toastLabel = UILabel(frame: CGRect(x: self.view.frame.size.width / 2 - CGFloat(width) / 2, y: 675.adjustedH, width: CGFloat(width), height: 40))
         

--- a/MUMENT/MUMENT/Global/Type/ToastMessageColorType.swift
+++ b/MUMENT/MUMENT/Global/Type/ToastMessageColorType.swift
@@ -1,0 +1,13 @@
+//
+//  ToastMessageColorType.swift
+//  MUMENT
+//
+//  Created by madilyn on 2022/11/04.
+//
+
+import Foundation
+
+enum ToastMessageColorType {
+    case black
+    case red
+}

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageBottomSheet.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageBottomSheet.swift
@@ -392,7 +392,7 @@ extension StorageBottomSheet: UICollectionViewDelegateFlowLayout {
 
         }else {
             collectionView.deselectItem(at: indexPath, animated: false)
-            self.showToastMessage(message: "태그는 최대 3개까지 선택할 수 있어요.")
+            self.showToastMessage(message: "태그는 최대 3개까지 선택할 수 있어요.", color: .black)
             
         }
         bottomTagSectionHeight = 70

--- a/MUMENT/MUMENT/Sources/Scenes/Write/WriteVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Write/WriteVC.swift
@@ -215,7 +215,7 @@ class WriteVC: BaseVC {
             self.setRadioButtonSelectStatus(button: self.firstListenButton, isSelected: true)
             self.setRadioButtonSelectStatus(button: self.againListenButton, isSelected: false)
             if self.isFirstListenActivated == false {
-                self.showToastMessage(message: "‘처음 들어요'는 한 곡당 한 번만 선택할 수 있어요.")
+                self.showToastMessage(message: "‘처음 들어요'는 한 곡당 한 번만 선택할 수 있어요.", color: .black)
                 self.setRadioButtonSelectStatus(button: self.firstListenButton, isSelected: false)
                 self.setRadioButtonSelectStatus(button: self.againListenButton, isSelected: true)
             }
@@ -370,7 +370,7 @@ extension WriteVC {
             case .success(let response):
                 if response is PostMumentResponseModel {
                     self.setDefaultView()
-                    self.showToastMessage(message: "🎉 뮤멘트가 작성되었어요!")
+                    self.showToastMessage(message: "🎉 뮤멘트가 작성되었어요!", color: .black)
                 }
             default:
                 self.makeAlert(title: MessageType.networkError.message)

--- a/MUMENT/MUMENT/Sources/Scenes/Write/WriteVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Write/WriteVC.swift
@@ -400,7 +400,7 @@ extension WriteVC: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if Int(feelTagCV.indexPathsForSelectedItems?.count ?? 0) + Int(impressionTagCV.indexPathsForSelectedItems?.count ?? 0) > 5 {
-            self.showToastMessage(message: "감상 태그는 최대 5개까지 선택할 수 있어요.")
+            self.showToastMessage(message: "감상 태그는 최대 5개까지 선택할 수 있어요.", color: .black)
             collectionView.deselectItem(at: indexPath, animated: true)
         } else {
             if let cell = collectionView.cellForItem(at: indexPath) as? WriteTagCVC {


### PR DESCRIPTION
## 🎸 작업한 내용
- 빨간색 토스트 메시지를 구현하였습니다.


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- showToastMessage 함수에 color 파라미터를 추가하였고, `self.showToastMessage(message: "감상 태그는 최대 5개까지 선택할 수 있어요.", color: .black)` 처럼 사용하시면 됩니다~!


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-04 at 22 41 19](https://user-images.githubusercontent.com/43312096/199987945-c52c00b4-4e33-481d-b60f-0d1c74be8380.gif)


## 💽 관련 이슈
- Resolved: #158


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
