### PR TITLE
[FEAT] 카카오, 애플 로그인 

### DIFF
--- a/MUMENT/MUMENT.xcodeproj/project.pbxproj
+++ b/MUMENT/MUMENT.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		4D9734ED287EB022003EF546 /* MumentsOfRevisitedCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9734EC287EB022003EF546 /* MumentsOfRevisitedCVC.swift */; };
 		4D9734EF287EC748003EF546 /* MumentsOfRevisitedModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9734EE287EC748003EF546 /* MumentsOfRevisitedModel.swift */; };
 		4D9734F3287F3A41003EF546 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9734F2287F3A41003EF546 /* Preview.swift */; };
+		4DA2E1C32918D3FB0037F5BD /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 4DA2E1C22918D3FB0037F5BD /* KakaoSDK */; };
+		4DA2E1C52918D3FB0037F5BD /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 4DA2E1C42918D3FB0037F5BD /* KakaoSDKAuth */; };
 		4DC4D84E2889BA100060D00F /* MumentsByTagResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC4D84D2889BA100060D00F /* MumentsByTagResponseModel.swift */; };
 		4DC4D8502889BAC10060D00F /* MumentsOfRevisitedResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC4D84F2889BAC10060D00F /* MumentsOfRevisitedResponseModel.swift */; };
 		4DCD2844288942DE0012AF49 /* MumentDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D13A66F28882B1100197D2A /* MumentDetailService.swift */; };
@@ -328,12 +330,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				C74EC447287593BF0068EB46 /* RxSwift in Frameworks */,
+				4DA2E1C32918D3FB0037F5BD /* KakaoSDK in Frameworks */,
 				C74EC44C287594270068EB46 /* Alamofire in Frameworks */,
 				C74EC445287593BF0068EB46 /* RxRelay in Frameworks */,
 				C74EC43B287593910068EB46 /* SnapKit in Frameworks */,
 				C74EC441287593BF0068EB46 /* RxBlocking in Frameworks */,
 				C74EC443287593BF0068EB46 /* RxCocoa in Frameworks */,
 				C74EC43E2875939F0068EB46 /* Then in Frameworks */,
+				4DA2E1C52918D3FB0037F5BD /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -842,6 +846,8 @@
 				C74EC444287593BF0068EB46 /* RxRelay */,
 				C74EC446287593BF0068EB46 /* RxSwift */,
 				C74EC44B287594270068EB46 /* Alamofire */,
+				4DA2E1C22918D3FB0037F5BD /* KakaoSDK */,
+				4DA2E1C42918D3FB0037F5BD /* KakaoSDKAuth */,
 			);
 			productName = MUMENT;
 			productReference = C74EC41628758D220068EB46 /* MUMENT.app */;
@@ -877,6 +883,7 @@
 				C74EC43C2875939F0068EB46 /* XCRemoteSwiftPackageReference "Then" */,
 				C74EC43F287593BF0068EB46 /* XCRemoteSwiftPackageReference "RxSwift" */,
 				C74EC44A287594270068EB46 /* XCRemoteSwiftPackageReference "Alamofire" */,
+				4DA2E1C12918D3FB0037F5BD /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			productRefGroup = C74EC41728758D220068EB46 /* Products */;
 			projectDirPath = "";
@@ -1267,6 +1274,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		4DA2E1C12918D3FB0037F5BD /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 		C74EC439287593910068EB46 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
@@ -1302,6 +1317,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4DA2E1C22918D3FB0037F5BD /* KakaoSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4DA2E1C12918D3FB0037F5BD /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDK;
+		};
+		4DA2E1C42918D3FB0037F5BD /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4DA2E1C12918D3FB0037F5BD /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
 		C74EC43A287593910068EB46 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C74EC439287593910068EB46 /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/MUMENT/MUMENT.xcodeproj/project.pbxproj
+++ b/MUMENT/MUMENT.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		4DC4D84D2889BA100060D00F /* MumentsByTagResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentsByTagResponseModel.swift; sourceTree = "<group>"; };
 		4DC4D84F2889BAC10060D00F /* MumentsOfRevisitedResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentsOfRevisitedResponseModel.swift; sourceTree = "<group>"; };
 		4DE75A8128CCBAE400BC3EC4 /* MumentsByTagCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MumentsByTagCardView.swift; sourceTree = "<group>"; };
+		4DE7693D2918DF0E00747F79 /* MUMENT.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MUMENT.entitlements; sourceTree = "<group>"; };
 		4DEED412288B32B300C6337B /* DeleteAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAPI.swift; sourceTree = "<group>"; };
 		4DEED414288B32E500C6337B /* DeleteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteService.swift; sourceTree = "<group>"; };
 		4DF61684287C43CC00ECC421 /* UITableViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+.swift"; sourceTree = "<group>"; };
@@ -601,6 +602,7 @@
 		C74EC41828758D220068EB46 /* MUMENT */ = {
 			isa = PBXGroup;
 			children = (
+				4DE7693D2918DF0E00747F79 /* MUMENT.entitlements */,
 				C74EC42728758D230068EB46 /* Info.plist */,
 				C7BC6B4C2876ACD9008C75CE /* Global */,
 				C73FC9BA287C193A0017F2DA /* Network */,
@@ -1192,6 +1194,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_ENTITLEMENTS = MUMENT/MUMENT.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = N4RT4KGQK9;
@@ -1224,6 +1227,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_ENTITLEMENTS = MUMENT/MUMENT.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = N4RT4KGQK9;

--- a/MUMENT/MUMENT/Application/AppDelegate.swift
+++ b/MUMENT/MUMENT/Application/AppDelegate.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import KakaoSDKCommon
+import KakaoSDKAuth
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -14,7 +16,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         sleep(1)
-        // Override point for customization after application launch.
+        
+        // 네이티브 앱 키(카카오 디벨로퍼 계정에서 제공)를 사용해 iOS SDK를 초기화합니다.
+        KakaoSDK.initSDK(appKey: "a03c85e89f6892684a4533911f5ab502")
+
         return true
     }
 
@@ -31,7 +36,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
 

--- a/MUMENT/MUMENT/Application/SceneDelegate.swift
+++ b/MUMENT/MUMENT/Application/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import KakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -15,9 +16,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = AutoSignInVC()
+        window?.rootViewController = SignInVC()
         window?.makeKeyAndVisible()
     }
+    
+    // 카카오톡에서 서비스 앱으로 돌아왔을 때 카카오 로그인 처리를 정상적으로 완료하기 위해 필요한 코드입니다. 
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+            if let url = URLContexts.first?.url {
+                if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                    _ = AuthController.handleOpenUrl(url: url)
+                }
+            }
+        }
 
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.

--- a/MUMENT/MUMENT/Info.plist
+++ b/MUMENT/MUMENT/Info.plist
@@ -4,11 +4,18 @@
 <dict>
 	<key>CFBundleURLTypes</key>
 	<array>
-		<dict/>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakaoa03c85e89f6892684a4533911f5ab502</string>
+			</array>
+		</dict>
 	</array>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
-		<string>kakaompassauth</string>
+		<string>kakaokompassauth</string>
 		<string>kakaolink</string>
 	</array>
 	<key>UIAppFonts</key>

--- a/MUMENT/MUMENT/Info.plist
+++ b/MUMENT/MUMENT/Info.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict/>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>NotoSans-SemiBold.ttf</string>

--- a/MUMENT/MUMENT/MUMENT.entitlements
+++ b/MUMENT/MUMENT/MUMENT.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/MUMENT/MUMENT/Sources/Scenes/SignIn/SignInVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/SignIn/SignInVC.swift
@@ -65,7 +65,7 @@ final class SignInVC: BaseVC {
                     else {
                         print("loginWithKakaoTalk() success.")
                         
-                        //서버한테 보내서 jwt 토큰 발급 받기
+                        // TODO: - 서버한테 보내서 jwt 토큰 발급 받기
                         _ = oauthToken
                     }
                 }
@@ -177,11 +177,15 @@ extension SignInVC: ASAuthorizationControllerDelegate {
             print("fullName", fullName as Any)
             print("email", email as Any)
             
+            // TODO: - 서버한테 보내서 jwt 토큰 발급 받기
+            
             // iCloud의 패스워드를 연동해 왔을 때
         case let passwordCredential as ASPasswordCredential:
             let username = passwordCredential.user
             let password = passwordCredential.password
             print("username", username)
+            
+            // TODO: - 서버한테 보내서 jwt 토큰 발급 받기
         default:
             break
         }
@@ -191,31 +195,15 @@ extension SignInVC: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         print("apple 로그인 사용자 인증 실패")
         print("error \(error)")
-        // TODO: - 필요 시 추가적인 에러 처리
+        
+        // 필요 시 추가적인 에러 처리
     }
-    
-//    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-//      let appleIDProvider = ASAuthorizationAppleIDProvider()
-//      appleIDProvider.getCredentialState(forUserID: KeychainItem.currentUserIdentifier) { (credentialState, error) in
-//        switch credentialState {
-//        case .authorized:
-//          // Authorization Logic
-//        case .revoked, .notFound:
-//          // Not Authorization Logic
-//          DispatchQueue.main.async {
-//            self.window?.rootViewController?.showLoginViewController()
-//          }
-//        default:
-//          break
-//        }
-//      }
-//      return true
-//    }
 }
 
 // MARK: - ASAuthorizationControllerPresentationContextProviding
 extension SignInVC: ASAuthorizationControllerPresentationContextProviding {
     
+    /// 애플 로그인 UI를 어디에 띄울지 가장 적합한 뷰 앵커를 반환합니다.
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return self.view.window!
     }

--- a/MUMENT/MUMENT/Sources/Scenes/SignIn/SignInVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/SignIn/SignInVC.swift
@@ -9,6 +9,7 @@ import UIKit
 import Then
 import SnapKit
 import SafariServices
+import KakaoSDKUser
 
 final class SignInVC: BaseVC {
     
@@ -53,7 +54,21 @@ final class SignInVC: BaseVC {
     // MARK: - Functions
     private func setButtonActions(){
         kakaoSignInButton.press{
-            print("카카오로 계속하기 버튼 클릭됨")
+            
+            // 카카오톡 설치 여부 확인
+            if (UserApi.isKakaoTalkLoginAvailable()) {
+                UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+                    if let error = error {
+                        print(error)
+                    }
+                    else {
+                        print("loginWithKakaoTalk() success.")
+
+                        //서버한테 보내서 jwt 토큰 발급 받기
+                        _ = oauthToken
+                    }
+                }
+            }
         }
         
         appleSignInButton.press{


### PR DESCRIPTION
## 🎸 작업한 내용
- 카카오 로그인 
  - 카카오 디벨로퍼 사이트에 앱 등록
  - KakaoSDK SPM으로 설치 
  - Info.plist 설정
  - AppDelegate, SceneDelegate 코드 작성
  - 버튼 클릭 이벤트 핸들러 코드 작성
- 애플 로그인 
  - 애플 디벨로퍼 사이트에 앱 등록(ID 설정)하는 건 정빈 언니가 예전에 해뒀다고 해서 그 이후 과정부터 이어서 했습니다
  - Target > Signing & Capabilities 에 Capability > Sign In with Apple 추가
  - 버튼 이벤트 클릭 핸들러 코드, 사용자 인증 성공 여부에 따른 처리 코드 작성

## 🎶 PR Point
- 로그아웃 기능을 만들지 않아 그런지 한 번만 확인할 수 있는 걸 모르고 카카오 로그인 부분은 녹화를 하지 못했습니다. 
  - 터미널 출력 화면으로 대체해 첨부합니당
- 사용자 정보를 받아오는 범위가 애플로그인은 이름과 이메일이 최대이지만 카카오로그인은 동의 항목 옵션이 많은 것 같은데 이 부분은 서버/기획 분들께 여쭤보면 될까요?
<img width="500" alt="스크린샷 2022-11-07 오후 2 44 08" src="https://user-images.githubusercontent.com/25932970/200248387-5e90b39f-de9f-4d29-aa52-af4e88c50187.png">

- 정보를 받아온 이후의 처리는 서버 분들과 얘기해 본 뒤에 해야 하는 것 같아 정보를 받아오는 부분까지만 구현한 뒤 풀리퀘 올립니다.
  - 추가로 해야 할 부분이 있다면 말씀해주시면 감사하겠습니당!
- 적절한 PR label이 뭔지 모르겠지만 일단 UI로 달았습니당

## 📸 스크린샷
|카카오|애플|
|--|--|
|<img width="822" alt="스크린샷 2022-11-07 오후 3 28 51" src="https://user-images.githubusercontent.com/25932970/200248847-ac5cdb97-4946-47b4-8a85-63cb19457fda.png">|<img width="494" alt="스크린샷 2022-11-07 오후 3 57 59" src="https://user-images.githubusercontent.com/25932970/200248318-fb98e296-1172-42d3-876b-9ea579cff324.png">|

https://user-images.githubusercontent.com/25932970/200250132-852e3e95-1568-46ee-bece-2b38ed5886a0.mp4



## 💽 관련 이슈
- Resolved: #143 
