### PR TITLE
[FIX] 보관함 뮤멘트 작성 날짜 로직 수정

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/LikedMumentVC.swift
@@ -216,7 +216,7 @@ extension LikedMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, U
             }
             emptyView.isHidden = true
             let year = dateArray[indexPath.section] / 100
-            let month = dateArray[indexPath.section] % 10
+            let month = dateArray[indexPath.section] - (100 * year)
             header.setHeader(year, month)
             return header
         }else {

--- a/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/MyMumentVC.swift
@@ -215,7 +215,7 @@ extension MyMumentVC: UICollectionViewDelegate, UICollectionViewDataSource, UICo
             }
             emptyView.isHidden = true
             let year = dateArray[indexPath.section] / 100
-            let month = dateArray[indexPath.section] % 10
+            let month = dateArray[indexPath.section] - (100 * year)
             header.setHeader(year, month)
             return header
         }else {


### PR DESCRIPTION
## 🎸 작업한 내용
- 기존의 보관함 뮤멘트 컬렉션 뷰의 날짜를 보여주는 헤더의 날짜가 10월이 0월 로 보이는 버그가 있어 로직을 수정하였습니다.
- 원래 202207 이라는 값에서 100으로 나눠서 2022라는 연도 값 구하고  %10 해서 10의 자리의 값을 월로 받았는데 다시 보니까 10,11,12월은 0,1,2값이 되버림, 그래서 기존 값 202210 - (100x년도) 그니까 202210 - 2022x100으로 10이라는 월값을 구하는 것으로 변경하였습니다.

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 이슈가 이거라 2줄 고치고 PR 올리는게 부끄럽네요,,,


## 📸 스크린샷
| 기존 | 변경 |
| - | - |
| <!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
<img width="340" alt="Screen Shot 2022-12-02 at 2 37 54 AM" src="https://user-images.githubusercontent.com/32871014/205270526-626f0a21-c722-4478-a803-8af66273b2bf.png"> | <img width="320" alt="Screen Shot 2022-12-02 at 7 20 59 PM" src="https://user-images.githubusercontent.com/32871014/205271249-4cdd78db-77f1-4355-acd1-21eef0528702.png">


## 💽 관련 이슈
- Resolved: #181 



<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
