### PR TITLE
[FEAT] 보관함 마이페이지 버튼 연결

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageVC.swift
@@ -179,7 +179,6 @@ class StorageVC: BaseVC {
     }
     
     private func setPressAction() {
-        
         profileButton.press {
             self.pushToMyPageMainVC()
         }


### PR DESCRIPTION
## 🎸 작업한 내용
- 처리할 이슈가 단순히 보관함에서 마이페이지 연결이라 별 내용이 없습니다,,!


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 보관함에서 마이페이지로 넘어간 상태에서 보관함 탭을 누르면 마이페이지가 닫히고 다시 보관함 뷰컨이 뜨는데 이때 보관함 뷰컨이 위에 쌓이는건지 아니면 탭바컨트롤러에서 탭을 눌렀을때 rootVC 가 보관함인 네이게이션 컨트롤러를 호출하기 때문에 따로 뷰가 쌓이지 않게 되는건지 궁금합니다~!!
`let storageTab = makeTabVC(vc: BaseNC(rootViewController: StorageVC()), tabBarTitle: "보관함", tabBarImg: "mumentIconLibraryOff", tabBarSelectedImg: "mumentIconLibraryOn")
        storageTab.tabBarItem.tag = 2`

- 연결만 하고 올리려다 보니까 보관함의 마이페이지로 가는 버튼이 작은 프로필 이미지로 되어있어 보관함에서 프로필 이미지를 가져와서 마이페이지로 넘겨줘야 하나 생각이 들었습니다만 우선 연결만 한 상태로 PR 올립니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

![Simulator Screen Recording - iPhone 14 Pro - 2022-12-02 at 20 43 40](https://user-images.githubusercontent.com/32871014/205285510-6725fc3e-6e90-421a-8f2d-1943c100d154.gif)


## 💽 관련 이슈
- Resolved: #180 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
