### PR TITLE
[FEAT] 로그아웃 구현

### DIFF
--- a/MUMENT/MUMENT/Sources/Components/MumentAlertWithButtons/MumentAlertWithButtons.swift
+++ b/MUMENT/MUMENT/Sources/Components/MumentAlertWithButtons/MumentAlertWithButtons.swift
@@ -47,14 +47,15 @@ class MumentAlertWithButtons: BaseVC{
         $0.titleLabel?.font = .mumentB4M14
         $0.setTitleColor(.mBlack2, for: .normal)
     }
-    let OKButton = UIButton(type: .system).then {
-        $0.setTitle("확인", for: .normal)
+    lazy var OKButton = UIButton(type: .system).then {
+        $0.setTitle(okTitle ?? "확인", for: .normal)
         $0.titleLabel?.font = .mumentB4M14
         $0.setTitleColor(.mPurple1, for: .normal)
     }
     
     var titleType: MumentAlertTitleType?
     var alertHeight: CGFloat?
+    private var okTitle: String? = nil
     
     // MARK: - Initialization
     init(titleType: MumentAlertTitleType) {
@@ -62,6 +63,14 @@ class MumentAlertWithButtons: BaseVC{
         
         setPresentation()
         self.titleType = titleType
+    }
+    
+    init(titleType: MumentAlertTitleType, OKTitle: String) {
+        super.init(nibName: nil, bundle: nil)
+        
+        setPresentation()
+        self.titleType = titleType
+        okTitle = OKTitle
     }
     
     required init?(coder: NSCoder) {
@@ -110,10 +119,6 @@ class MumentAlertWithButtons: BaseVC{
         OKButton.press { [weak self] in
             self?.dismiss(animated: true)
         }
-    }
-    
-    func setOKButtonTitle(title : String) {
-        OKButton.setTitle(title, for: .normal)
     }
 }
 

--- a/MUMENT/MUMENT/Sources/Scenes/Mypage/Main/MypageMainVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Mypage/Main/MypageMainVC.swift
@@ -148,8 +148,8 @@ extension MypageMainVC: UITableViewDataSource {
                 cell.setVersionLabel(version: "1.0")
                 
                 cell.setSignOutAction { [weak self] in
-                    let mumentAlert = MumentAlertWithButtons(titleType: .onlyTitleLabel)
-                    mumentAlert.setOKButtonTitle(title: "로그아웃")
+                    let mumentAlert =  MumentAlertWithButtons(titleType: .onlyTitleLabel, OKTitle: "로그아웃")
+//                    mumentAlert.setOKButtonTitle(title: "")
                     mumentAlert.setTitle(title: "로그아웃하시겠어요?")
                     self?.present(mumentAlert, animated: true)
                     mumentAlert.OKButton.press { [weak self] in


### PR DESCRIPTION
## 🎸 작업한 내용
- 로그아웃 기능 구현
- MumentAlertWithButtons 코드 수정


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
-  마이페이지의 '로그아웃' 클릭 시 UserDefaults에 저장된 refreshToken을 만료된 refreshToken으로 바꾼 후 로그인 뷰로 이동하게 만들어 '재로그인 플로우'에 들어가도록 만들었습니다
- MumentAlertWithButtons의 '확인' 텍스트가 들어가는 곳을 '로그아웃'으로 바꾸어야 하는데 button의 title을 바꾸는 메소드를 따로 만들어 호출하면 실행 시 '로그아웃' 레이블이 눈에 보일 정도로 느리게 적용되었습니다. 그래서 okTitle이라는 프로퍼티를 만들어 MumentAlertWithButtons 생성 시에 해당 값을 설정할 수 있게 하고 button은 lazy로 만들어 이후 okTitle 값에 따라 button Title이 정해지도록 하였습니다. 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

https://user-images.githubusercontent.com/25932970/215586598-7820e9fc-c8a6-4a14-881b-f76e6703ac73.MP4



## 💽 관련 이슈
- Resolved: #145 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
