### PR TITLE
[FIX] 보관함에서 뮤멘트 상세보기 이동시 제대로 되지 않는 버그 수정

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageMumentVC.swift
@@ -158,12 +158,13 @@ final class StorageMumentVC: BaseVC {
                 dateArray = [1]
             }
             
-            for i in 0...dateArray.count-1 {
+            for i in 0...dateArray.count - 1 {
                 storageMumentData.forEach {
                     let mdate = $0.year * 100 + $0.month
                     /// 뮤멘트 데이터의 날짜가 미리 정렬해놓은 날짜 배열의 값과 일치 할때
                     if mdate == dateArray[i] {
-                        dateDictionary[mdate]! += 1
+                        guard let numOfMuments = dateDictionary[mdate] else { return }
+                        dateDictionary[mdate] = numOfMuments + 1
                     }
                 }
             }
@@ -266,7 +267,7 @@ extension StorageMumentVC: UICollectionViewDataSource{
                 case .myMument:
                     listCell.setDefaultCardUI()
                     if indexPath.section == 0 {
-                        if indexPath.row > storageMumentData.count - 1{
+                        if indexPath.row > storageMumentData.count - 1 {
                             listCell.setEmptyCardView()
                             storageMumentCV.reloadData()
                             return listCell
@@ -275,15 +276,17 @@ extension StorageMumentVC: UICollectionViewDataSource{
                         return listCell
                     }
                     var mData = 0
-                    for i in 0...indexPath.section-1{
-                        mData += (dateDictionary[dateArray[i]])!
+                    for i in 0...indexPath.section - 1 {
+                        if let numOfMuments = dateDictionary[dateArray[i]] {
+                            mData += numOfMuments
+                        }
                     }
                     listCell.setDefaultCardData(storageMumentData[mData + indexPath.row])
                     return listCell
                     
                 case .likedMument:
                     if indexPath.section == 0 {
-                        if indexPath.row > storageMumentData.count - 1{
+                        if indexPath.row > storageMumentData.count - 1 {
                             listCell.setEmptyCardView()
                             storageMumentCV.reloadData()
                             return listCell
@@ -293,7 +296,7 @@ extension StorageMumentVC: UICollectionViewDataSource{
                         return listCell
                     }
                     var mData = 0
-                    for i in 0...indexPath.section-1{
+                    for i in 0...indexPath.section - 1 {
                         mData += (dateDictionary[dateArray[i]])!
                     }
                     listCell.setWithoutHeartCardUI()
@@ -303,7 +306,7 @@ extension StorageMumentVC: UICollectionViewDataSource{
                 
             case .albumCell:
                 if indexPath.section == 0 {
-                    if indexPath.row > storageMumentData.count - 1{
+                    if indexPath.row > storageMumentData.count - 1 {
                         albumCell.setEmptyCardView()
                         storageMumentCV.reloadData()
                         return albumCell
@@ -312,8 +315,10 @@ extension StorageMumentVC: UICollectionViewDataSource{
                     return albumCell
                 }
                 var mData = 0
-                for i in 0...indexPath.section-1{
-                    mData += (dateDictionary[dateArray[i]])!
+                for i in 0...indexPath.section - 1 {
+                    if let numOfMuments = dateDictionary[dateArray[i]] {
+                        mData += numOfMuments
+                    }
                 }
                 albumCell.fetchData(storageMumentData[mData + indexPath.row])
                 return albumCell
@@ -369,8 +374,10 @@ extension StorageMumentVC: UICollectionViewDelegate {
         case storageMumentCV:
             var mData = 0
             if indexPath.section != 0 {
-                for i in 0...indexPath.section-1{
-                    mData += (dateDictionary[dateArray[i]])!
+                for i in 0...indexPath.section - 1 {
+                    if let numOfMuments = dateDictionary[dateArray[i]] {
+                        mData += numOfMuments
+                    }
                 }
             }
             let mumentData = storageMumentData[mData + indexPath.row]


### PR DESCRIPTION
## 🎸 작업한 내용
- 이전에 서버에서 받아온 뮤멘트 데이터를 섹션에 맞게 넘겨주지 않아 첫번째 섹션에서 넘어갈 때만 제대로 데이터가 넘겨지고 다른 섹션은 제대로 되지 않는 문제를 섹션을 구분할때 쓰는 날짜 배열과 딕셔너리를 통해 구분을 해주었습니다.
dataArray = 월별 섹션을 구분하는 날짜 배열
dateDictionary = 날짜 값을 키로 가지면 각 날짜별 몇개의 뮤멘트가 있는지를 value로 가짐

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

https://user-images.githubusercontent.com/32871014/217158269-428f68d0-9071-4dbe-97a3-04dc1d48a740.mov


## 💽 관련 이슈
- Resolved: #271 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
