### PR TITLE
[CHORE] 뮤멘트 신고시 두 번 Pop VC 구현

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/ReportMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/ReportMumentVC.swift
@@ -247,12 +247,16 @@ extension ReportMumentVC {
                     self.postUserBlock()
                 }else {
                     if let navigationController = self.navigationController as? BaseNC, let previousVC = navigationController.previousViewController as? BaseVC {
+                        navigationController.popViewController(animated: false)
                         
-                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
-                            previousVC.showToastMessage(message: "신고가 접수되었습니다.", color: .black)
+                        if let previousNC = previousVC.navigationController as? BaseNC, let beforePreviousVC = previousNC.previousViewController as? BaseVC {
+                            previousNC.popViewController(animated: true)
+                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(100)) {
+                                beforePreviousVC.showToastMessage(message: "신고가 접수되었습니다.", color: .black)
+                            }
+                            beforePreviousVC.viewWillAppear(true)
                         }
-                        navigationController.popViewController(animated: true)
-                        previousVC.viewWillAppear(true)
+                        
                     }
                 }
                 default:
@@ -269,21 +273,29 @@ extension ReportMumentVC {
                     debugPrint("block",statusCode)
                 }
                 if let navigationController = self.navigationController as? BaseNC, let previousVC = navigationController.previousViewController as? BaseVC {
+                    navigationController.popViewController(animated: false)
                     
-                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
-                        previousVC.showToastMessage(message: "신고 및 차단이 완료되었습니다.", color: .black)
+                    if let previousNC = previousVC.navigationController as? BaseNC, let beforePreviousVC = previousNC.previousViewController as? BaseVC {
+                        previousNC.popViewController(animated: true)
+                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
+                            beforePreviousVC.showToastMessage(message: "신고 및 차단이 완료되었습니다.", color: .black)
+                        }
+                        beforePreviousVC.viewWillAppear(true)
                     }
-                    navigationController.popViewController(animated: true)
-                    previousVC.viewWillAppear(true)
+                    
                 }
             default:
                 if let navigationController = self.navigationController as? BaseNC, let previousVC = navigationController.previousViewController as? BaseVC {
+                    navigationController.popViewController(animated: false)
                     
-                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
-                        previousVC.showToastMessage(message: "신고가 접수되었습니다.", color: .black)
+                    if let previousNC = previousVC.navigationController as? BaseNC, let beforePreviousVC = previousNC.previousViewController as? BaseVC {
+                        previousNC.popViewController(animated: true)
+                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(100)) {
+                            beforePreviousVC.showToastMessage(message: "신고가 접수되었습니다.", color: .black)
+                        }
+                        beforePreviousVC.viewWillAppear(true)
                     }
-                    navigationController.popViewController(animated: true)
-                    previousVC.viewWillAppear(true)
+                    
                 }
             }
         }


### PR DESCRIPTION
## 🎸 작업한 내용
- 뮤멘트 신고 완료시 신고한 뮤멘트 상세가 아닌 그 이전 뷰로 가게 하였습니다.


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 뮤멘트 상세 이전 VC로 pop 1번, 뮤멘트 상세로 pop 2번 이라고 했을때
  1번과 2번으로의 Pop애니메이션을 어떻게 하는게 좋을지 문의드립니다.
- 개인적으로 1번 트루 2번 폴스가 자연스러운듯요

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
| 1번, 2번 둘다 false | 1번 false 2번 true | 1번, 2번 둘 다 true | 1번 true, 2번 false |
| ---------------- | ------------------ | ---------------- | ----------------- |
| https://user-images.githubusercontent.com/32871014/217299074-aa99b4e0-975f-49d6-a752-2e46ec550340.MP4 | https://user-images.githubusercontent.com/32871014/217299322-b1c723ba-a6e9-4111-94d9-b69fae14d7d6.MP4 | https://user-images.githubusercontent.com/32871014/217299513-b9d600ac-d14e-40c2-9d56-be4f6ea87c7a.MP4 | https://user-images.githubusercontent.com/32871014/217300557-4643c686-4418-4a06-85cd-fd39fcbc2b56.MP4 |



## 💽 관련 이슈
- Resolved: #280 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
