### PR TITLE
[Chore] 보관함 컬렉션 뷰 여백 조정

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Storage/StorageMumentVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Storage/StorageMumentVC.swift
@@ -90,6 +90,11 @@ final class StorageMumentVC: BaseVC {
         getMumentDataWithTagInt(selectedTagsInt)
     }
     
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        storageMumentCV.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 45, right: 0)
+    }
+    
     // MARK: - Function
     private func setEmptyView() {
         switch tabType {
@@ -448,6 +453,9 @@ extension StorageMumentVC: UICollectionViewDelegateFlowLayout {
         case selectedTagsCV:
             return .zero
         case storageMumentCV:
+            if section == 0 {
+                return CGSize(width: view.frame.size.width, height: 47.adjustedH)
+            }
             return CGSize(width: view.frame.size.width, height: 87.adjustedH)
         default:
             return .zero


### PR DESCRIPTION
## 🎸 작업한 내용
- 보관함 컬렉션 뷰 상단 여백이 너무 길어 간격 조정
- 보관함 컬렉션 뷰 하단이 탭바와 너무 붙어 있어 간격 조정


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 300번 이슈는 제가 가져갑니다 >_0


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
| 상단 | 하단 |
| ---- | ----- |
| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-08 at 22 36 41](https://user-images.githubusercontent.com/32871014/217546524-ecdbc7b5-e594-48e5-813d-febd65161bcb.png) | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-08 at 22 36 50](https://user-images.githubusercontent.com/32871014/217546469-7a4496f8-a64b-4ad5-9074-647fca2dba0b.png) |


## 💽 관련 이슈
- Resolved: #300 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
