### PR TITLE
[FIX] 뮤멘트 상세 수정시 하단 비밀글 UI 버그 수정

### DIFF
--- a/MUMENT/MUMENT/Sources/Components/DetailMumentCard/DetailMumentCardView.swift
+++ b/MUMENT/MUMENT/Sources/Components/DetailMumentCard/DetailMumentCardView.swift
@@ -44,6 +44,7 @@ final class DetailMumentCardView: UIView {
     private let tagSubStackView: UIStackView = UIStackView().then {
         $0.axis = .horizontal
         $0.spacing = 8
+        $0.alignment = .leading
     }
     private let contentsLabel: UILabel = UILabel().then {
         $0.textColor = .mGray1
@@ -129,6 +130,9 @@ final class DetailMumentCardView: UIView {
             }
         }else {
             heartStackView.addArrangedSubviews([heartButton, likedUserButton])
+            heartStackView.snp.updateConstraints {
+                $0.left.equalTo(self.safeAreaLayoutGuide).offset(5)
+            }
             heartButton.snp.makeConstraints {
                 $0.height.width.equalTo(38.adjustedH)
             }
@@ -269,7 +273,7 @@ extension DetailMumentCardView {
         }
         heartStackView.snp.makeConstraints {
             $0.top.equalTo(createdAtLabel.snp.bottom)
-            $0.left.equalTo(self.safeAreaLayoutGuide).offset(5)
+            $0.left.equalTo(self.safeAreaLayoutGuide).offset(13)
             $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(5)
         }
         shareButton.snp.makeConstraints {


### PR DESCRIPTION
## 🎸 작업한 내용
- 뮤멘트 하단 비밀글/좋아요 부분을 서버의 isPrivate 여부에 따라 스택뷰를 그리게 분기처리를 했는데 
   수정시 이전에 addSubView 되었던게 계속 남아 있어 버그가 생겨 
   addArrangeSubView를 하기 전에 subView들을 삭제 해주도록 하였습니다. 
  (removeAllArrangeSubView는 제대로 먹히지 않았습니다.)



## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 기존에 스택뷰로 구현을 해서 지금처럼 수정을 했는데 그냥 두 경우다 같은 위치에 놓고 isPrivate에 따라 hidden 처리 및 UserInteractionEnabled 처리를 하는게 더 간단 했을 것 같다는 생각도 드네용


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPhone 13 mini - 2023-02-15 at 02 30 19](https://user-images.githubusercontent.com/32871014/218814693-9a43ad9a-46de-4ba7-8489-da6ae4499974.gif)


## 💽 관련 이슈
- Resolved: #341 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
