### PR TITLE
[FIX] 뮤멘트 상세보기 하트, 텍스트 간격 조정

### DIFF
--- a/MUMENT/MUMENT/Sources/Components/DetailMumentCard/DetailMumentCardView.swift
+++ b/MUMENT/MUMENT/Sources/Components/DetailMumentCard/DetailMumentCardView.swift
@@ -58,6 +58,7 @@ final class DetailMumentCardView: UIView {
     }
     private lazy var heartStackView: UIStackView = UIStackView().then {
         $0.axis = .horizontal
+        $0.spacing = 5
     }
     private let heartButton: UIButton = UIButton().then {
         $0.configuration = .plain()
@@ -131,10 +132,10 @@ final class DetailMumentCardView: UIView {
         }else {
             heartStackView.addArrangedSubviews([heartButton, likedUserButton])
             heartStackView.snp.updateConstraints {
-                $0.left.equalTo(self.safeAreaLayoutGuide).offset(5)
+                $0.left.equalTo(self.safeAreaLayoutGuide).offset(13)
             }
             heartButton.snp.makeConstraints {
-                $0.height.width.equalTo(38.adjustedH)
+                $0.height.width.equalTo(21.adjustedH)
             }
         }
         
@@ -272,9 +273,9 @@ extension DetailMumentCardView {
             $0.left.equalTo(self.safeAreaLayoutGuide).offset(13)
         }
         heartStackView.snp.makeConstraints {
-            $0.top.equalTo(createdAtLabel.snp.bottom)
+            $0.top.equalTo(createdAtLabel.snp.bottom).offset(10)
             $0.left.equalTo(self.safeAreaLayoutGuide).offset(13)
-            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(5)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(16)
         }
         shareButton.snp.makeConstraints {
             $0.top.equalTo(createdAtLabel.snp.bottom)


### PR DESCRIPTION
## 🎸 작업한 내용
- 뮤멘트 상세보기 하트, 텍스트 간격 조정(줄이기) QA 반영


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 하트 버튼 크기를 이미지 크기와 동일하게 맞추고 버튼 크기 변화에 따른 레이아웃 간격들을 조정했습니다


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
|수정 전|수정 후|
|--|--|
|![IMG_7393 2](https://user-images.githubusercontent.com/25932970/219561174-c62f0bed-7cad-4107-93eb-d6f35097b9e1.PNG)|![IMG_7394](https://user-images.githubusercontent.com/25932970/219561063-4d82821d-3318-4ce7-b36b-bfc83486036f.PNG)|

## 💽 관련 이슈
- Resolved: #359


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
