### PR TITLE
[FIX] 최근 검색 목록 20개 고정

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
@@ -240,6 +240,9 @@ extension SearchVC: UITableViewDelegate {
                 SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: self.recentSearchData, forKey: UserDefaults.Keys.recentSearch)
             } else {
                 self.recentSearchData.append(searchResultData[indexPath.row])
+                if self.recentSearchData.count > 20 {
+                    self.recentSearchData.remove(atOffsets: IndexSet(0...self.recentSearchData.count - 21))
+                }
                 SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: self.recentSearchData, forKey: UserDefaults.Keys.recentSearch)
             }
         }

--- a/MUMENT/MUMENT/Sources/Scenes/Write/SearchForWriteView.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Write/SearchForWriteView.swift
@@ -220,6 +220,9 @@ extension SearchForWriteView: UITableViewDelegate {
                 SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: self.recentSearchData, forKey: UserDefaults.Keys.recentSearch)
             } else {
                 self.recentSearchData.append(self.searchResultData[indexPath.row])
+                if self.recentSearchData.count > 20 {
+                    self.recentSearchData.remove(atOffsets: IndexSet(0...self.recentSearchData.count - 21))
+                }
                 SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: self.recentSearchData, forKey: UserDefaults.Keys.recentSearch)
             }
             NotificationCenter.default.post(name: .sendSearchResult, object: self.searchResultData[indexPath.row])


### PR DESCRIPTION
## 🎸 작업한 내용
- [곡 검색 결과] ‘최근 검색한 곡’ 무한으로 누적 →  20개까지 제한 수정 요청


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 이전에 쌓였던 곡 검색 기록은, 새로운 검색한 곡을 추가하게 되거나, 전체 삭제 후 반영됩니다!
- 곡 검색 데이터가 추가될 경우, 20개가 넘으면 초과된 개수만큼 0번 인덱스부터 삭제하도록 구현하였습니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![RPReplay_Final1676916259](https://user-images.githubusercontent.com/43312096/220175547-3ceb7617-83a5-4b2d-bfee-f64efac067c8.gif)


## 💽 관련 이슈
- Resolved: #361


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
