### PR TITLE
[FIX] 최근 검색 기록 배열 remove하는 방식 변경

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Search/SearchVC.swift
@@ -241,7 +241,9 @@ extension SearchVC: UITableViewDelegate {
             } else {
                 self.recentSearchData.append(searchResultData[indexPath.row])
                 if self.recentSearchData.count > 20 {
-                    self.recentSearchData.remove(atOffsets: IndexSet(0...self.recentSearchData.count - 21))
+                    for _ in 0..<self.recentSearchData.count - 20 {
+                        self.recentSearchData.removeFirst()
+                    }
                 }
                 SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: self.recentSearchData, forKey: UserDefaults.Keys.recentSearch)
             }

--- a/MUMENT/MUMENT/Sources/Scenes/Write/SearchForWriteView.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Write/SearchForWriteView.swift
@@ -221,7 +221,9 @@ extension SearchForWriteView: UITableViewDelegate {
             } else {
                 self.recentSearchData.append(self.searchResultData[indexPath.row])
                 if self.recentSearchData.count > 20 {
-                    self.recentSearchData.remove(atOffsets: IndexSet(0...self.recentSearchData.count - 21))
+                    for _ in 0..<self.recentSearchData.count - 20 {
+                        self.recentSearchData.removeFirst()
+                    }
                 }
                 SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: self.recentSearchData, forKey: UserDefaults.Keys.recentSearch)
             }


### PR DESCRIPTION
## 🎸 작업한 내용
- 최근 검색 기록이 20개 이상일 경우, 오래된 element를 remove하는 방식을 remove(atOffsets:) 함수 대신 removeFirst() 함수를 for문에 넣는 것으로 변경


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 변경 이유는... 이거 땜에 테플 배포하는 데 두 시간 걸렸는데... 분명히 개발할 때는 아무 문제 없이 함수가 작동했는데 Archive만 하면 이 부분에서 에러가 뜨는 거예요????? 그래서 엄청나게 뒤지다가 발견한 것은... 기존에 쓰던 remove(atOffsets:) 함수는 SwiftUI에서 쓰이는 함수인데, 코드 내에서 import SwiftUI를 명시하지 않아도 실행은 되지만 (마치 import 안 해도 사용할 수 있는 라이브러리가 있는 것처럼) Archive를 할 때에는 이 부분이 걸려서 함수가 작동하지 않았던 문제였습니다..~ 그래서 그냥 removeFirst() 함수를 for문으로 돌려서 사용하였습니다!

## 💽 관련 이슈
- Resolved: #385


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
