### PR TITLE
[FIX] 회원탈퇴/로그아웃 시 최근 곡 검색 결과 초기화

### DIFF
--- a/MUMENT/MUMENT/Global/Base/BaseVC.swift
+++ b/MUMENT/MUMENT/Global/Base/BaseVC.swift
@@ -86,6 +86,7 @@ extension BaseVC {
         UserDefaultsManager.accessToken = nil
         UserDefaultsManager.refreshToken = nil
         UserDefaultsManager.userId = nil
+        SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: [], forKey: UserDefaults.Keys.recentSearch)
         UserInfo.shared = UserInfo.init()
     }
     


### PR DESCRIPTION
## 🎸 작업한 내용
- 회원탈퇴/로그아웃 시 최근 곡 검색 결과 초기화가 안 되던 문제를 수정하였습니다
[곡 검색 결과] 탈퇴하고 재가입했는데 그 전 최근 검색한 곡 기록이 남아있어요..ㄷ ㄷ ㄷ ㄷ 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

https://user-images.githubusercontent.com/43312096/220667768-82c20ff3-894b-4c10-acaf-c0e126bc68dd.mp4



## 💽 관련 이슈
- Resolved: #387


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
