### PR TITLE
[FEAT] 뮤멘트 상세보기 관련 GA 연결

### DIFF
--- a/MUMENT/MUMENT/Global/Extensions/UINavigationController+.swift
+++ b/MUMENT/MUMENT/Global/Extensions/UINavigationController+.swift
@@ -12,9 +12,9 @@ extension UINavigationController {
         self.viewControllers.count > 1 ? self.viewControllers[self.viewControllers.count - 2] : nil
     }
     
-    public func pushViewController(_ viewController: UIViewController,
-                                   animated: Bool,
-                                   completion: (() -> Void)?) {
+    func pushViewController(_ viewController: UIViewController,
+                            animated: Bool,
+                            completion: (() -> Void)?) {
         CATransaction.begin()
         CATransaction.setCompletionBlock(completion)
         pushViewController(viewController, animated: animated)

--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/MumentDetailVC.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/MumentDetailVC.swift
@@ -60,18 +60,7 @@ final class MumentDetailVC: BaseVC, UIActionSheetDelegate {
         super.viewWillAppear(animated)
         self.showTabbar()
         requestGetMumentDetail()
-        
-        let previousViewController = self.navigationController?.previousViewController
-        if previousViewController is HomeVC {
-            sendGAEvent(eventName: .mument_detail_page, parameterValue: .from_home)
-            print("from_home GA")
-        } else if previousViewController is SongDetailVC {
-            sendGAEvent(eventName: .mument_detail_page, parameterValue: .from_song_detail_page)
-            print("from_song_detail_page GA")
-        } else if previousViewController is MumentHistoryVC {
-            sendGAEvent(eventName: .mument_detail_page, parameterValue: .from_history_list)
-            print("from_history_list GA")
-        }
+        sendMumentDetailGAEvent()
     }
     
     // MARK: - Functions
@@ -202,6 +191,17 @@ final class MumentDetailVC: BaseVC, UIActionSheetDelegate {
                 }
             })
             .disposed(by: self.othersMumentActionSheetVC.disposeBag )
+    }
+    
+    private func sendMumentDetailGAEvent() {
+        let previousViewController = self.navigationController?.previousViewController
+        if previousViewController is HomeVC {
+            sendGAEvent(eventName: .mument_detail_page, parameterValue: .from_home)
+        } else if previousViewController is SongDetailVC {
+            sendGAEvent(eventName: .mument_detail_page, parameterValue: .from_song_detail_page)
+        } else if previousViewController is MumentHistoryVC {
+            sendGAEvent(eventName: .mument_detail_page, parameterValue: .from_history_list)
+        }
     }
 }
 
@@ -378,5 +378,4 @@ extension MumentDetailVC {
             }
         }
     }
-    
 }


### PR DESCRIPTION
## 🎸 작업한 내용
- mument_detail_page GA 연결
  - from_home
  - from_song_detail_page
  - from_history_list


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 홈, 곡 상세보기, 뮤멘트 히스토리 뷰컨트롤러에서 뮤멘트 디테일 뷰로 pushViewController를 할 때 sendGAEvent 함수를 작성할까 했지만 각 뷰컨트롤러에 있는 모든 cell들과 연결짓는 것보다 이동된 뮤멘트 디테일 뷰에서 이전 뷰를 판단하는 게 더 간단할 것 같아 extension에 있던 변수를 사용해 구현하였습니다!


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
프린트 문을 찍어 확인하였고 확인 후 삭제하였습니다.
사진은 세 타입 중 하나인 뮤멘트 히스토리 뷰에서 넘어왔을 때의 스크린캡처본만 첨부합니다!
<img width="430" alt="스크린샷 2023-03-02 오전 11 53 49" src="https://user-images.githubusercontent.com/25932970/222319032-1f7d14c5-6288-4863-8b61-881547073dc3.png">


## 💽 관련 이슈
- Resolved: #373


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
