### PR TITLE
[FEAT] 공식계정 뮤멘트 메뉴(케밥) 버튼 숨김처리

### DIFF
--- a/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/DetailMumentCardView.swift
+++ b/MUMENT/MUMENT/Sources/Scenes/Home/MumentDetail/DetailMumentCardView.swift
@@ -79,13 +79,11 @@ final class DetailMumentCardView: UIView {
         $0.configuration?.image = UIImage(named: "instagram")
     }
     private var isLiked: Bool = false
-    
     private let privateLabel = UILabel().then {
         $0.font = .mumentC1R12
         $0.text = "비밀글"
         $0.textColor = .mGray1
     }
-    
     private var mumentId: Int = 0
     
     // MARK: - Initialization
@@ -115,17 +113,22 @@ final class DetailMumentCardView: UIView {
         self.mumentId = mumentId
         hideMenuButton(userId: cellData.user.id)
         songInfoView.setData(musicData)
-        
+        setHeartStackViewLayout(isPrivate: cellData.isPrivate)
+        setTags()
+        updateContentLayout(content: cellData.content)
+    }
+    
     private func hideMenuButton(userId: Int) {
         if OfficialIdInfo.shared.idList.contains(userId) {
             self.menuIconButton.isHidden = true
         }
     }
     
+    private func setHeartStackViewLayout(isPrivate: Bool) {
         heartStackView.subviews.forEach {
             $0.removeFromSuperview()
         }
-        if cellData.isPrivate {
+        if isPrivate {
             heartStackView.addArrangedSubview(privateLabel)
             heartStackView.snp.updateConstraints {
                 $0.left.equalTo(self.safeAreaLayoutGuide).offset(13)
@@ -139,9 +142,6 @@ final class DetailMumentCardView: UIView {
                 $0.height.width.equalTo(21.adjustedH)
             }
         }
-        
-        setTags()
-        self.updateContentLayout(content: cellData.content)
     }
     
     private func setTags() {


### PR DESCRIPTION
## 🎸 작업한 내용
- 현재 뮤멘트 상세보기의 유저 id가 OfficialIdInfo에 저장된 공식계정 id 리스트에 있을 때 뮤멘트 상세의 메뉴버튼을 숨김
- 뮤멘트 상세보기 카드뷰 내 setData안에서 처리되는 비밀글, 공개글에 따른 레이아웃 처리 코드를 따로 함수화


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 스크린샷은 뮤멘트 유저 아이디를 어드민 아이디 리스트 중 하나의 값을 넣어 동작 확인한것 입니다.

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
| 메뉴 버튼 숨김 |
| ------------ |
| ![Simulator Screen Shot - iPhone 13 mini - 2023-03-11 at 11 54 42](https://user-images.githubusercontent.com/32871014/224462157-001f7682-5045-4db7-b55f-8faf28d1808d.png) |

## 💽 관련 이슈
- Resolved: #419 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
