### PR TITLE
[REFACTOR] UserInfo 클래스 코드 수정

### DIFF
--- a/MUMENT/MUMENT/Global/Base/BaseVC.swift
+++ b/MUMENT/MUMENT/Global/Base/BaseVC.swift
@@ -87,7 +87,7 @@ extension BaseVC {
         UserDefaultsManager.refreshToken = nil
         UserDefaultsManager.userId = nil
         SearchResultResponseModelElement.setSearchResultModelToUserDefaults(data: [], forKey: UserDefaults.Keys.recentSearch)
-        UserInfo.shared = UserInfo.init()
+        UserInfo.shared.resetUserInfo()
     }
     
     func getUserProfile(completion: @escaping () -> (Void)) {

--- a/MUMENT/MUMENT/Global/Singleton/UserInfo.swift
+++ b/MUMENT/MUMENT/Global/Singleton/UserInfo.swift
@@ -10,8 +10,6 @@ import UIKit
 class UserInfo {
     static var shared = UserInfo()
     
-    init() { }
-    
     var userId: Int?
     var accessToken: String? = ""
     var refreshToken: String? = ""
@@ -20,4 +18,17 @@ class UserInfo {
     var profileImageURL: String = APIConstants.defaultProfileImageURL
     var isPenaltyUser: Bool = false
     var isFirstVisit: Bool = true
+    
+    private init() { }
+    
+    func resetUserInfo() {
+        userId = nil
+        accessToken = ""
+        refreshToken = ""
+        isAppleLogin = nil
+        nickname = ""
+        profileImageURL = APIConstants.defaultProfileImageURL
+        isPenaltyUser = false
+        isFirstVisit = true
+    }
 }


### PR DESCRIPTION
## 🎸 작업한 내용
- UserInfo 클래스 코드를 일부 수정합니다
  - constructor는 private으로 수정합니다
  - resetUserInfo 메소드를 추가합니다


## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 주로 보안을 위해 도입하는 싱글톤 패턴은 생성자를 private으로 설정합니다. 생성자를 public으로 두었을 경우 static variable shared에 생성해 참조한 인스턴스를 외부에서 원한다면 덮어씌울 수 있어 보안을 위해 해당 패턴을 사용한 동기가 흐려지게 되기 때문입니다. 작은 프로젝트에서는 괜찮지만 규모가 커지는 경우 실수할 우려가 있기에 이를 private으로 설정한다고 합니다. 
- 기존 코드의 탈퇴 시 UserInfo에 저장된 내용을 초기화하기 위해 새로운 인스턴스를 만들어 덮어씌우던 부분도 위 수정에 따라 생성자를 사용하는 대신 해당 기능 수행에 필요한 method를 추가해 이를 사용하도록 수정하였습니다.
- 403 에러가 뜨던 것은 개발 서버 코드에서 애플 api 접근을 위한 개발자 토큰에 오류가 있어 발생했던 문제였지만 해결되었습니다.

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 💽 관련 이슈
- Resolved: #429


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
